### PR TITLE
Convert "__" to ":" in enviroment variables

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -38,7 +38,7 @@ impl ConfigurationProvider for EnvironmentVariablesConfigurationProvider {
         for (key, value) in vars() {
             if key.to_uppercase().starts_with(&prefix) {
                 let new_key = key[prefix_len..].to_string();
-                data.insert(new_key.to_uppercase(), (new_key, value));
+                data.insert(new_key.to_uppercase().replace("__", ":"), (new_key, value));
             }
         }
 

--- a/test/env.rs
+++ b/test/env.rs
@@ -1,5 +1,5 @@
 use config::{ext::*, *};
-use std::env::var;
+use std::env::{set_var, var};
 
 #[test]
 fn add_env_vars_should_load_environment_variables() {
@@ -28,4 +28,18 @@ fn add_env_vars_should_load_filtered_environment_variables() {
     // assert
     assert_eq!(value, &expected);
     assert!(config.get("PATH").is_none())
+}
+
+#[test]
+fn double_underscores_are_translated() {
+    // arrange
+    let expected = "myvalue";
+    set_var("Foo__Bar__Baz", expected);
+    let config = DefaultConfigurationBuilder::new().add_env_vars().build();
+
+    // act
+    let value = config.get("Foo:Bar:Baz").unwrap();
+
+    // assert
+    assert_eq!(value, expected);
 }


### PR DESCRIPTION
The documentation states that "__" in enviroment variable names should be converted to ":". This seems to be missing in the implementation, and is added by this PR.