### PR TITLE
Add ConfigurationSection to Configuration Conversion

### DIFF
--- a/guide/src/guide/abstractions.md
+++ b/guide/src/guide/abstractions.md
@@ -36,6 +36,7 @@ pub trait ConfigurationSection:
     fn key(&self) -> &str;
     fn path(&self) -> &str;
     fn value(&self) -> Value;
+    fn as_config(&self) -> Box<dyn Configuration>;
 }
 ```
 

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "more-config"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2018"
 authors = ["Chris Martinez <chris.s.martinez@hotmail.com>"]
 description = "Provides support for configuration"

--- a/src/default.rs
+++ b/src/default.rs
@@ -308,8 +308,9 @@ cfg_if! {
 }
 
 /// Represent a configuration section.
+#[derive(Clone)]
 pub struct DefaultConfigurationSection {
-    root: Box<dyn ConfigurationRoot>,
+    root: Pc<dyn ConfigurationRoot>,
     path: String,
 }
 
@@ -322,7 +323,7 @@ impl DefaultConfigurationSection {
     /// * `path` - The path of the configuration section
     pub fn new(root: Box<dyn ConfigurationRoot>, path: &str) -> Self {
         Self {
-            root,
+            root: root.into(),
             path: path.to_owned(),
         }
     }
@@ -383,6 +384,10 @@ impl ConfigurationSection for DefaultConfigurationSection {
 
     fn value(&self) -> Value {
         self.root.get(&self.path).unwrap_or_default()
+    }
+
+    fn as_config(&self) -> Box<dyn Configuration> {
+        Box::new(self.clone())
     }
 }
 

--- a/src/root.rs
+++ b/src/root.rs
@@ -61,7 +61,7 @@ pub trait ConfigurationRoot:
     /// Gets the [`ConfigurationProvider`](crate::ConfigurationProvider) sequence for this configuration.
     fn providers(&self) -> Box<dyn ConfigurationProviderIterator + '_>;
 
-    /// Converts the [`ConfigurationRoot``] into a [`Configuration``](crate::Configuration).
+    /// Converts the [`ConfigurationRoot`] into a [`Configuration`](crate::Configuration).
     fn as_config(&self) -> Box<dyn Configuration>;
 }
 

--- a/src/section.rs
+++ b/src/section.rs
@@ -16,6 +16,9 @@ pub trait ConfigurationSection:
 
     /// Gets the section value.
     fn value(&self) -> Value;
+
+    /// Converts the [`ConfigurationSection`] into a [`Configuration`](crate::Configuration).
+    fn as_config(&self) -> Box<dyn Configuration>;
 }
 
 pub mod ext {


### PR DESCRIPTION
Add conversion function from `ConfigurationSection` to `Configuration` (e.g. downcast). This functionality is required for some data binding operations. The `ConfigurationRoot` trait already has this ability, but `ConfigurationSection` also requires it.