### PR TITLE
Fix Map Deserialization

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "more-config"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2018"
 rust-version = "1.60"
 authors = ["Chris Martinez <chris.s.martinez@hotmail.com>"]

--- a/src/de.rs
+++ b/src/de.rs
@@ -161,6 +161,20 @@ impl<'de> de::Deserializer<'de> for Val {
         SeqDeserializer::new(values.into_iter()).deserialize_seq(visitor)
     }
 
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        use crate::ConfigurationPath::Relative;
+
+        let values = self
+            .0
+            .iter(Some(Relative))
+            .map(|(key, value)| (key, (*value).clone()));
+
+        MapDeserializer::new(values).deserialize_map(visitor)
+    }
+
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: de::Visitor<'de>,
@@ -221,7 +235,7 @@ impl<'de> de::Deserializer<'de> for Val {
 
     serde::forward_to_deserialize_any! {
         char str string unit
-        bytes byte_buf map unit_struct tuple_struct
+        bytes byte_buf unit_struct tuple_struct
         identifier tuple ignored_any
     }
 }


### PR DESCRIPTION
Maps should be able to be deserialized from configurations. The process is almost identical to structs. This PR makes it possible to deserialize maps of key/value pairs with heterogenous types. The simplest use case would be `HashMap<String, String>`, but other types can combinations are possible.