### PR TITLE
Remove unnecessary generic argument on add_command_line_map

### DIFF
--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "more-config"
-version = "2.1.2"
+version = "2.1.3"
 edition = "2018"
 rust-version = "1.60"
 authors = ["Chris Martinez <chris.s.martinez@hotmail.com>"]

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -189,10 +189,7 @@ pub mod ext {
         /// # Arguments
         ///
         /// * `switch_mappings` - The mapping of switches to configuration values
-        fn add_command_line_map<I, S>(&mut self, switch_mappings: &[(S, S)]) -> &mut Self
-        where
-            I: Iterator<Item = S>,
-            S: AsRef<str>;
+        fn add_command_line_map<S: AsRef<str>>(&mut self, switch_mappings: &[(S, S)]) -> &mut Self;
     }
 
     impl CommandLineConfigurationBuilderExtensions for dyn ConfigurationBuilder {
@@ -203,11 +200,7 @@ pub mod ext {
             self
         }
 
-        fn add_command_line_map<I, S>(&mut self, switch_mappings: &[(S, S)]) -> &mut Self
-        where
-            I: Iterator<Item = S>,
-            S: AsRef<str>,
-        {
+        fn add_command_line_map<S: AsRef<str>>(&mut self, switch_mappings: &[(S, S)]) -> &mut Self {
             self.add(Box::new(CommandLineConfigurationSource::new(
                 std::env::args(),
                 switch_mappings,
@@ -224,11 +217,7 @@ pub mod ext {
             self
         }
 
-        fn add_command_line_map<I, S>(&mut self, switch_mappings: &[(S, S)]) -> &mut Self
-        where
-            I: Iterator<Item = S>,
-            S: AsRef<str>,
-        {
+        fn add_command_line_map<S: AsRef<str>>(&mut self, switch_mappings: &[(S, S)]) -> &mut Self {
             self.add(Box::new(CommandLineConfigurationSource::new(
                 std::env::args(),
                 switch_mappings,


### PR DESCRIPTION
Remove unnecessary generic argument from `CommandLineConfigurationBuilderExtensions.add_command_line_map`. Fixes #15