### PR TITLE
Fix Extension Trait Lifetimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rust
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "more-config"
-version = "2.1.3"
+version = "2.1.4"
 edition = "2018"
 rust-version = "1.60"
 authors = ["Chris Martinez <chris.s.martinez@hotmail.com>"]

--- a/src/binder.rs
+++ b/src/binder.rs
@@ -37,7 +37,7 @@ pub trait ConfigurationBinder {
     fn get_value_or_default<T: FromStr + Default>(&self, key: impl AsRef<str>) -> Result<T, T::Err>;
 }
 
-impl ConfigurationBinder for dyn Configuration {
+impl ConfigurationBinder for dyn Configuration + '_ {
     fn reify<T: DeserializeOwned>(&self) -> T {
         from_config::<T>(self).unwrap()
     }

--- a/src/chained.rs
+++ b/src/chained.rs
@@ -112,7 +112,7 @@ pub mod ext {
         fn add_configuration(&mut self, configuration: Box<dyn Configuration>) -> &mut Self;
     }
 
-    impl ChainedBuilderExtensions for dyn ConfigurationBuilder {
+    impl ChainedBuilderExtensions for dyn ConfigurationBuilder + '_ {
         fn add_configuration(&mut self, configuration: Box<dyn Configuration>) -> &mut Self {
             self.add(Box::new(ChainedConfigurationSource::new(configuration)));
             self

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -192,7 +192,7 @@ pub mod ext {
         fn add_command_line_map<S: AsRef<str>>(&mut self, switch_mappings: &[(S, S)]) -> &mut Self;
     }
 
-    impl CommandLineConfigurationBuilderExtensions for dyn ConfigurationBuilder {
+    impl CommandLineConfigurationBuilderExtensions for dyn ConfigurationBuilder + '_ {
         fn add_command_line(&mut self) -> &mut Self {
             self.add(Box::new(CommandLineConfigurationSource::from(
                 std::env::args(),

--- a/src/env.rs
+++ b/src/env.rs
@@ -99,7 +99,7 @@ pub mod ext {
         fn add_env_vars_with_prefix(&mut self, prefix: &str) -> &mut Self;
     }
 
-    impl EnvironmentVariablesExtensions for dyn ConfigurationBuilder {
+    impl EnvironmentVariablesExtensions for dyn ConfigurationBuilder + '_ {
         fn add_env_vars(&mut self) -> &mut Self {
             self.add_env_vars_with_prefix("")
         }

--- a/src/ini.rs
+++ b/src/ini.rs
@@ -183,7 +183,7 @@ pub mod ext {
         fn add_ini_file<T: Into<FileSource>>(&mut self, file: T) -> &mut Self;
     }
 
-    impl IniConfigurationExtensions for dyn ConfigurationBuilder {
+    impl IniConfigurationExtensions for dyn ConfigurationBuilder + '_ {
         fn add_ini_file<T: Into<FileSource>>(&mut self, file: T) -> &mut Self {
             self.add(Box::new(IniConfigurationSource::new(file.into())));
             self

--- a/src/json.rs
+++ b/src/json.rs
@@ -253,7 +253,7 @@ pub mod ext {
         fn add_json_file<T: Into<FileSource>>(&mut self, file: T) -> &mut Self;
     }
 
-    impl JsonConfigurationExtensions for dyn ConfigurationBuilder {
+    impl JsonConfigurationExtensions for dyn ConfigurationBuilder + '_ {
         fn add_json_file<T: Into<FileSource>>(&mut self, file: T) -> &mut Self {
             self.add(Box::new(JsonConfigurationSource::new(file.into())));
             self

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -85,7 +85,7 @@ pub mod ext {
         fn add_in_memory<S: AsRef<str>>(&mut self, data: &[(S, S)]) -> &mut Self;
     }
 
-    impl MemoryConfigurationBuilderExtensions for dyn ConfigurationBuilder {
+    impl MemoryConfigurationBuilderExtensions for dyn ConfigurationBuilder + '_ {
         fn add_in_memory<S: AsRef<str>>(&mut self, data: &[(S, S)]) -> &mut Self {
             self.add(Box::new(MemoryConfigurationSource::new(data)));
             self

--- a/src/section.rs
+++ b/src/section.rs
@@ -36,7 +36,7 @@ pub mod ext {
         fn exists(&self) -> bool;
     }
 
-    impl ConfigurationSectionExtensions for dyn ConfigurationSection {
+    impl ConfigurationSectionExtensions for dyn ConfigurationSection + '_ {
         fn exists(&self) -> bool {
             !self.value().is_empty() || !self.children().is_empty()
         }

--- a/src/xml.rs
+++ b/src/xml.rs
@@ -496,7 +496,7 @@ pub mod ext {
         fn add_xml_file<T: Into<FileSource>>(&mut self, file: T) -> &mut Self;
     }
 
-    impl XmlConfigurationExtensions for dyn ConfigurationBuilder {
+    impl XmlConfigurationExtensions for dyn ConfigurationBuilder + '_ {
         fn add_xml_file<T: Into<FileSource>>(&mut self, file: T) -> &mut Self {
             self.add(Box::new(XmlConfigurationSource::new(file.into())));
             self


### PR DESCRIPTION
Explicitly adds the current scope lifetime `'_` so that `&dyn Trait` implementations are not assumed to be `'static`. Fixes #17.