### PR TITLE
Add Support for Deserialize::deserialize_in_place

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,37 @@
-[package]
-name = "more-config"
+[workspace]
+members = [".", "derive"]
+
+[workspace.package]
 version = "3.0.0"
 edition = "2021"
 rust-version = "1.79"
 authors = ["Chris Martinez <chris.s.martinez@hotmail.com>"]
+license = "MIT"
+repository = "https://github.com/commonsensesoftware/more-rs-config"
+
+[workspace.dependencies]
+proc-macro2 = "1"
+proptest = "1"
+quote = "1"
+serde = "1.0"
+serde_derive_internals = "0.29"
+serde_json = "1.0"
+syn = { version = "2", features = ["full", "parsing", "printing"] }
+trybuild = "1"
+yaml-rust2 = "0.9"
+
+[package]
+name = "more-config"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "Provides support for configuration"
 keywords = ["more", "configuration", "config"]
-license = "MIT"
 readme = "README.md"
 homepage = "https://commonsensesoftware.github.io/more-rs-config/"
-repository = "https://github.com/commonsensesoftware/more-rs-config"
 
 # RUSTDOCFLAGS="--cfg docsrs"; cargo +nightly doc
 [package.metadata.docs.rs]
@@ -36,6 +58,7 @@ default = ["cmd", "env", "mem"]
 binder = ["dep:serde"]
 chained = []
 cmd = []
+derive = ["dep:more-config-derive", "binder"]
 env = []
 ini = ["dep:configparser", "more-changetoken/fs"]
 json = ["dep:serde_json", "more-changetoken/fs"]
@@ -43,19 +66,16 @@ mem = []
 typed = ["dep:serde"]
 xml = ["dep:xml_rs", "more-changetoken/fs"]
 yaml = ["dep:yaml-rust2", "more-changetoken/fs"]
-all = ["binder", "chained", "cmd", "env", "ini", "json", "mem", "typed", "xml", "yaml"]
-
-[workspace.dependencies]
-serde = "1.0"
-yaml-rust2 = "0.9"
+all = ["chained", "cmd", "derive", "env", "ini", "json", "mem", "typed", "xml", "yaml"]
 
 [dependencies]
+more-config-derive = { path = "derive", optional = true }
 arc-swap = "1.9.1"
 configparser = { version = "3.1.0", optional = true }
 indexmap = "2.14.0"
 more-changetoken = "2.1.0"
 serde = { workspace = true, optional = true }
-serde_json = { version = "1.0", optional = true }
+serde_json = { workspace = true, optional = true }
 thiserror = "2.0.18"
 tracing = "0.1.40"
 xml_rs = { version = "1.0.0", package = "xml", optional = true }
@@ -63,6 +83,7 @@ yaml-rust2 = { workspace = true, optional = true }
 
 [dev-dependencies]
 more-config = { path = ".", features = ["all"] }
+proptest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tempfile = "3.27.0"
 test-case = "3.3.1"
@@ -71,3 +92,7 @@ yaml-rust2.workspace = true
 [[example]]
 name = "demo"
 path = "examples/demo.rs"
+
+[[example]]
+name = "partial-bind"
+path = "examples/partial_bind.rs"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This crate provides the following features:
 - **chained** - Chain multiple configuration providers
 - **cmd** - Configuration provided by command-line arguments
 - **env** - Configuration provided by environment variables
+- **derive** - Enables full and partial configuration deserialization using **serde**
 - **ini** - Configuration provided by an \*.ini file
 - **json** - Configuration provided by a \*.json file
 - **mem** - Configuration provided by in-memory data
@@ -113,6 +114,8 @@ fn main() -> Result<(), Box<dyn Error + 'static>> {
 
 ## Examples
 
+### Basic
+
 A simple demonstration application is provided that combines in-memory settings, a demo.json file, and allows command
 line arguments. Run it with:
 
@@ -124,6 +127,14 @@ To highlight overriding configuration via the command line, run it with:
 
 ```bash
 cargo run --example demo -- --text "I'm a teapot!"
+```
+
+### Partial Updates
+
+A variant of the demonstration application is provided that illustrates how to support partial configuration binding.
+
+```bash
+cargo run --example partial-bind
 ```
 
 ## Minimum Supported Rust Version

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "more-config-derive"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Derive macro for more-config Deserialize"
+keywords = ["more", "configuration", "config", "derive"]
+
+[lib]
+name = "config_derive"
+path = "src/lib.rs"
+proc-macro = true
+
+[dependencies]
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+serde_derive_internals = { workspace = true }
+syn = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+trybuild = { workspace = true }

--- a/derive/src/attr.rs
+++ b/derive/src/attr.rs
@@ -1,0 +1,226 @@
+use serde::ast::{Container, Style};
+use serde::attr::{Default as SerdeDefault, RenameRule};
+use serde::{Ctxt, Derive};
+use serde_derive_internals as serde;
+use syn::{parenthesized, parse_quote, token, Attribute, DeriveInput, Error, Expr, Ident, Member, Result, Token, Type};
+
+/// Container-level serde attributes relevant to our derive.
+pub struct ContainerAttrs {
+    /// The `rename_all` rule applied to field names, if any.
+    #[allow(dead_code)]
+    pub rename_all: Option<RenameRule>,
+
+    /// Whether the container has `#[serde(default)]`.
+    pub has_default: bool,
+}
+
+/// Field-level serde attributes relevant to our derive.
+pub struct FieldAttrs {
+    /// The serialized name after applying `rename_all` and `rename`.
+    pub serialized_name: String,
+
+    /// Additional aliases from `#[serde(alias = "...")]`.
+    pub aliases: Vec<String>,
+
+    /// Whether the field has `#[serde(skip)]` or `#[serde(skip_deserializing)]`.
+    pub skip_deserializing: bool,
+
+    /// Whether the field has `#[serde(default)]`.
+    pub has_field_default: bool,
+
+    /// The default expression from `#[serde(default = "path")]`, if any.
+    pub default_expr: Option<Expr>,
+}
+
+/// Parsed representation of a struct with all attribute information resolved.
+pub struct ParsedStruct {
+    pub container_attrs: ContainerAttrs,
+    pub fields: Vec<ParsedField>,
+}
+
+/// A single field with its identity and resolved attributes.
+pub struct ParsedField {
+    pub ident: Ident,
+    pub ty: Type,
+    pub attrs: FieldAttrs,
+}
+
+/// The list of serde attributes that this derive macro does not support.
+const UNSUPPORTED_ATTRS: &[&str] = &[
+    "flatten",
+    "with",
+    "deserialize_with",
+    "bound",
+    "from",
+    "try_from",
+    "tag",
+    "untagged",
+];
+
+/// Parse serde attributes from a `DeriveInput` representing a named struct.
+///
+/// # Remarks
+///
+/// This function uses `serde_derive_internals` to parse all serde attributes, then checks for unsupported attributes
+/// and extracts the information we need.
+///
+/// Returns `Ok(ParsedStruct)` on success, or `Err(Error)` if unsupported attributes are detected or parsing fails.
+pub fn parse_struct_attrs(input: &DeriveInput) -> Result<ParsedStruct> {
+    // check for unsupported attributes before doing full parsing
+    check_unsupported_attrs(input)?;
+
+    // Use serde_derive_internals to parse all attributes.
+    let cx = Ctxt::new();
+    let container = match Container::from_ast(&cx, input, Derive::Deserialize) {
+        Some(c) => c,
+        None => {
+            // If Container::from_ast returns None, check for errors from cx.
+            return Err(cx.check().unwrap_err());
+        }
+    };
+
+    // check if serde_derive_internals reported any errors
+    cx.check()?;
+
+    // extract container-level attributes
+    let rename_all_rules = container.attrs.rename_all_rules();
+    let rename_rule = rename_all_rules.deserialize;
+    let rename_all = if rename_rule == RenameRule::None {
+        None
+    } else {
+        Some(rename_rule)
+    };
+    let has_default = !container.attrs.default().is_none();
+    let container_attrs = ContainerAttrs {
+        rename_all,
+        has_default,
+    };
+
+    // extract field-level attributes
+    let fields = match &container.data {
+        serde::ast::Data::Struct(Style::Struct, fields) => fields,
+        _ => {
+            return Err(Error::new_spanned(
+                input,
+                "config::Deserialize can only be derived for structs with named fields",
+            ));
+        }
+    };
+
+    let parsed_fields: Vec<ParsedField> = fields
+        .iter()
+        .map(|field| {
+            let ident = match &field.member {
+                Member::Named(ident) => ident.clone(),
+                Member::Unnamed(_) => unreachable!("named struct fields have idents"),
+            };
+
+            let serialized_name = field.attrs.name().deserialize_name().to_owned();
+
+            let aliases: Vec<String> = field
+                .attrs
+                .aliases()
+                .iter()
+                .filter(|a| *a != &serialized_name)
+                .cloned()
+                .collect();
+
+            let skip_deserializing = field.attrs.skip_deserializing();
+
+            let (has_field_default, default_expr) = match field.attrs.default() {
+                SerdeDefault::None => (false, None),
+                SerdeDefault::Default => (true, None),
+                SerdeDefault::Path(path) => {
+                    let expr: Expr = parse_quote!(#path());
+                    (true, Some(expr))
+                }
+            };
+
+            ParsedField {
+                ident,
+                ty: field.ty.clone(),
+                attrs: FieldAttrs {
+                    serialized_name,
+                    aliases,
+                    skip_deserializing,
+                    has_field_default,
+                    default_expr,
+                },
+            }
+        })
+        .collect();
+
+    Ok(ParsedStruct {
+        container_attrs,
+        fields: parsed_fields,
+    })
+}
+
+/// Check for unsupported serde attributes on the container and its fields.
+///
+/// Scans `#[serde(...)]` attributes and emits compile errors for any that
+/// this derive macro does not support.
+fn check_unsupported_attrs(input: &DeriveInput) -> Result<()> {
+    let mut errors: Vec<Error> = Vec::new();
+
+    // check container-level attributes
+    for attr in &input.attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        check_meta_list_for_unsupported(attr, &mut errors);
+    }
+
+    // check field-level attributes
+    if let syn::Data::Struct(data) = &input.data {
+        for field in &data.fields {
+            for attr in &field.attrs {
+                if !attr.path().is_ident("serde") {
+                    continue;
+                }
+                check_meta_list_for_unsupported(attr, &mut errors);
+            }
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        let mut combined = errors.remove(0);
+        for err in errors {
+            combined.combine(err);
+        }
+        Err(combined)
+    }
+}
+
+/// Parse a `#[serde(...)]` attribute's nested meta items and check for unsupported ones.
+fn check_meta_list_for_unsupported(attr: &Attribute, errors: &mut Vec<Error>) {
+    let _ = attr.parse_nested_meta(|meta| {
+        for &unsupported in UNSUPPORTED_ATTRS {
+            if meta.path.is_ident(unsupported) {
+                errors.push(Error::new_spanned(
+                    &meta.path,
+                    format!("config::Deserialize does not support #[serde({})]", unsupported),
+                ));
+                // consume any value (= "...") or nested content so parsing continues
+                if meta.input.peek(Token![=]) {
+                    let _: Expr = meta.value()?.parse()?;
+                } else if meta.input.peek(token::Paren) {
+                    let _content;
+                    parenthesized!(_content in meta.input);
+                }
+                return Ok(());
+            }
+        }
+
+        // for supported attributes, consume their value so parsing continues
+        if meta.input.peek(Token![=]) {
+            let _: Expr = meta.value()?.parse()?;
+        } else if meta.input.peek(token::Paren) {
+            let _content;
+            parenthesized!(_content in meta.input);
+        }
+        Ok(())
+    });
+}

--- a/derive/src/gen.rs
+++ b/derive/src/gen.rs
@@ -1,0 +1,72 @@
+use crate::attr::{ContainerAttrs, FieldAttrs};
+use syn::{GenericArgument, Ident, PathArguments, Type};
+
+mod deserialize;
+mod in_place;
+
+pub use deserialize::deserialize;
+pub use in_place::deserialize_in_place;
+
+/// Represents a fully-analyzed struct ready for code generation.
+pub struct StructDef {
+    pub ident: syn::Ident,
+    pub generics: syn::Generics,
+    pub container_attrs: ContainerAttrs,
+    pub fields: Vec<FieldDef>,
+}
+
+/// Represents a single field with all resolved attributes.
+pub struct FieldDef {
+    pub ident: syn::Ident,
+    pub ty: syn::Type,
+    pub attrs: FieldAttrs,
+}
+
+/// Collects type parameter identifiers that appear in a type.
+///
+/// Given a type like `Vec<T>` and known type params `[T, U]`, this adds `T` to `found`.
+/// Recurses into generic arguments, references, tuples, arrays, and slices.
+pub(crate) fn collect_type_param_idents<'a>(ty: &Type, type_param_idents: &[&'a Ident], found: &mut Vec<&'a Ident>) {
+    match ty {
+        Type::Path(type_path) => {
+            if type_path.qself.is_none() && type_path.path.segments.len() == 1 {
+                let seg = &type_path.path.segments[0];
+                if let Some(&ident) = type_param_idents.iter().find(|&&id| *id == seg.ident) {
+                    found.push(ident);
+                }
+                if let PathArguments::AngleBracketed(args) = &seg.arguments {
+                    for arg in &args.args {
+                        if let GenericArgument::Type(inner_ty) = arg {
+                            collect_type_param_idents(inner_ty, type_param_idents, found);
+                        }
+                    }
+                }
+            } else {
+                for seg in &type_path.path.segments {
+                    if let PathArguments::AngleBracketed(args) = &seg.arguments {
+                        for arg in &args.args {
+                            if let GenericArgument::Type(inner_ty) = arg {
+                                collect_type_param_idents(inner_ty, type_param_idents, found);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Type::Reference(type_ref) => {
+            collect_type_param_idents(&type_ref.elem, type_param_idents, found);
+        }
+        Type::Tuple(type_tuple) => {
+            for elem in &type_tuple.elems {
+                collect_type_param_idents(elem, type_param_idents, found);
+            }
+        }
+        Type::Array(type_array) => {
+            collect_type_param_idents(&type_array.elem, type_param_idents, found);
+        }
+        Type::Slice(type_slice) => {
+            collect_type_param_idents(&type_slice.elem, type_param_idents, found);
+        }
+        _ => {}
+    }
+}

--- a/derive/src/gen/deserialize.rs
+++ b/derive/src/gen/deserialize.rs
@@ -1,0 +1,357 @@
+use crate::gen::{collect_type_param_idents, StructDef};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{GenericParam, Ident};
+
+/// Generate the full `fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error>`
+/// method body for a named struct.
+///
+/// The generated code:
+/// 1. Defines a `__Field` enum with variants for each non-skipped field plus `__Ignore`
+/// 2. Implements `Deserialize` for `__Field` to match string keys (including aliases)
+/// 3. Defines a `__Visitor` struct implementing `serde::de::Visitor` with `visit_map`
+/// 4. In `visit_map`: accumulates `Option<FieldType>` locals, matches keys, deserializes values
+/// 5. After map exhaustion: resolves each field (value, default, or missing_field error)
+/// 6. Skipped fields use `Default::default()` or the field's default expression
+/// 7. Unknown keys are consumed via `IgnoredAny`
+pub fn deserialize(struct_def: &StructDef) -> TokenStream {
+    let struct_ident = &struct_def.ident;
+    let struct_name_str = struct_ident.to_string();
+    let (_impl_generics, ty_generics, _where_clause) = struct_def.generics.split_for_impl();
+
+    // separate fields into non-skipped (deserialized) and skipped
+    let deserialized_fields: Vec<_> = struct_def
+        .fields
+        .iter()
+        .filter(|f| !f.attrs.skip_deserializing)
+        .collect();
+
+    let skipped_fields: Vec<_> = struct_def
+        .fields
+        .iter()
+        .filter(|f| f.attrs.skip_deserializing)
+        .collect();
+
+    // --- generate __Field enum variants ---
+    let field_enum_variants: Vec<_> = deserialized_fields
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format_ident!("__field{}", i))
+        .collect();
+
+    // --- generate match arms for __Field deserialization ---
+    let field_match_arms: Vec<TokenStream> = deserialized_fields
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
+            let variant = &field_enum_variants[i];
+            let primary_name = &field.attrs.serialized_name;
+
+            // Collect all names this field responds to: primary + aliases
+            let mut all_names: Vec<&str> = vec![primary_name.as_str()];
+            for alias in &field.attrs.aliases {
+                all_names.push(alias.as_str());
+            }
+
+            quote! {
+                #(#all_names)|* => Ok(__Field::#variant),
+            }
+        })
+        .collect();
+
+    // --- generate Option<T> locals for visit_map ---
+    let option_locals: Vec<TokenStream> = deserialized_fields
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
+            let local_name = format_ident!("__field{}", i);
+            let ty = &field.ty;
+            quote! {
+                let mut #local_name: Option<#ty> = None;
+            }
+        })
+        .collect();
+
+    // --- generate key match arms in visit_map ---
+    let visit_map_match_arms: Vec<TokenStream> = deserialized_fields
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
+            let variant = &field_enum_variants[i];
+            let local_name = format_ident!("__field{}", i);
+            let ty = &field.ty;
+            quote! {
+                __Field::#variant => {
+                    if #local_name.is_some() {
+                        return Err(serde::de::Error::duplicate_field(FIELDS[#i]));
+                    }
+                    #local_name = Some(map.next_value::<#ty>()?);
+                }
+            }
+        })
+        .collect();
+
+    // --- generate field resolution after map exhaustion ---
+    let field_resolutions: Vec<TokenStream> = deserialized_fields
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
+            let local_name = format_ident!("__field{}", i);
+            let field_ident = &field.ident;
+            let serialized_name = &field.attrs.serialized_name;
+
+            if field.attrs.has_field_default {
+                // field has its own #[serde(default)] or #[serde(default = "path")]
+                if let Some(ref default_expr) = field.attrs.default_expr {
+                    quote! {
+                        let #field_ident = #local_name.unwrap_or_else(|| #default_expr);
+                    }
+                } else {
+                    quote! {
+                        let #field_ident = #local_name.unwrap_or_default();
+                    }
+                }
+            } else if struct_def.container_attrs.has_default {
+                // container has #[serde(default)] — use Default::default() for absent fields
+                let ty = &field.ty;
+                quote! {
+                    let #field_ident = #local_name.unwrap_or_else(|| <#ty as Default>::default());
+                }
+            } else {
+                // required field — return missing_field error if absent
+                quote! {
+                    let #field_ident = #local_name.ok_or_else(|| {
+                        serde::de::Error::missing_field(#serialized_name)
+                    })?;
+                }
+            }
+        })
+        .collect();
+
+    // --- generate skipped field defaults ---
+    let skipped_field_defaults: Vec<TokenStream> = skipped_fields
+        .iter()
+        .map(|field| {
+            let field_ident = &field.ident;
+            if let Some(ref default_expr) = field.attrs.default_expr {
+                quote! {
+                    let #field_ident = #default_expr;
+                }
+            } else {
+                let ty = &field.ty;
+                quote! {
+                    let #field_ident = <#ty as Default>::default();
+                }
+            }
+        })
+        .collect();
+
+    // --- generate struct construction ---
+    let all_field_idents: Vec<_> = struct_def.fields.iter().map(|f| &f.ident).collect();
+
+    // --- FIELDS constant for error messages ---
+    let field_names_strs: Vec<&str> = deserialized_fields
+        .iter()
+        .map(|f| f.attrs.serialized_name.as_str())
+        .collect();
+
+    // --- generate the expecting message ---
+    let expecting_msg = format!("struct {}", struct_name_str);
+
+    // --- generate visitor struct and impl based on whether the struct is generic ---
+    let has_generics = !struct_def.generics.params.is_empty();
+
+    let (visitor_def, visitor_impl, visitor_instantiation) = if has_generics {
+        // For generic structs, the visitor needs type parameters and PhantomData.
+        let type_params: Vec<_> = struct_def
+            .generics
+            .params
+            .iter()
+            .filter_map(|p| match p {
+                GenericParam::Type(tp) => Some(tp),
+                _ => None,
+            })
+            .collect();
+
+        let type_param_idents: Vec<_> = type_params.iter().map(|tp| &tp.ident).collect();
+
+        // build struct definition params with existing bounds (needed when the struct
+        // itself has bounds, e.g. `struct Foo<T: Default>` — using `Foo<T>` in a field
+        // requires `T: Default` to be satisfied)
+        let struct_def_params: Vec<TokenStream> = type_params
+            .iter()
+            .map(|tp| {
+                let ident = &tp.ident;
+                let bounds = &tp.bounds;
+                if bounds.is_empty() {
+                    quote! { #ident }
+                } else {
+                    quote! { #ident: #bounds }
+                }
+            })
+            .collect();
+
+        // build bounds for the visitor impl: existing bounds + Deserialize<'de> only for
+        // type parameters that appear in deserializable fields.
+        let deserializable_type_params: std::collections::HashSet<&Ident> = deserialized_fields
+            .iter()
+            .flat_map(|f| {
+                let mut idents = Vec::new();
+                collect_type_param_idents(&f.ty, &type_param_idents, &mut idents);
+                idents
+            })
+            .collect();
+
+        let visitor_impl_bounds: Vec<TokenStream> = type_params
+            .iter()
+            .map(|tp| {
+                let ident = &tp.ident;
+                let bounds = &tp.bounds;
+                let needs_deserialize = deserializable_type_params.contains(ident);
+                match (bounds.is_empty(), needs_deserialize) {
+                    (true, true) => quote! { #ident: serde::Deserialize<'de> },
+                    (true, false) => quote! { #ident },
+                    (false, true) => quote! { #ident: #bounds + serde::Deserialize<'de> },
+                    (false, false) => quote! { #ident: #bounds },
+                }
+            })
+            .collect();
+
+        let visitor_def = quote! {
+            struct __Visitor<#(#struct_def_params),*>(core::marker::PhantomData<(#(#type_param_idents,)*)>);
+        };
+
+        let visitor_impl = quote! {
+            impl<'de, #(#visitor_impl_bounds),*> serde::de::Visitor<'de> for __Visitor<#(#type_param_idents),*> {
+                type Value = #struct_ident #ty_generics;
+
+                fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    f.write_str(#expecting_msg)
+                }
+
+                fn visit_map<__A>(self, mut map: __A) -> Result<Self::Value, __A::Error>
+                where
+                    __A: serde::de::MapAccess<'de>,
+                {
+                    #(#option_locals)*
+
+                    while let Some(key) = map.next_key::<__Field>()? {
+                        match key {
+                            #(#visit_map_match_arms)*
+                            __Field::__ignore => {
+                                let _ = map.next_value::<serde::de::IgnoredAny>()?;
+                            }
+                        }
+                    }
+
+                    #(#field_resolutions)*
+                    #(#skipped_field_defaults)*
+
+                    Ok(#struct_ident {
+                        #(#all_field_idents,)*
+                    })
+                }
+            }
+        };
+
+        let visitor_instantiation = quote! {
+            __Visitor::<#(#type_param_idents),*>(core::marker::PhantomData)
+        };
+
+        (visitor_def, visitor_impl, visitor_instantiation)
+    } else {
+        // for non-generic structs, use a simple unit struct visitor
+        let visitor_def = quote! {
+            struct __Visitor;
+        };
+
+        let visitor_impl = quote! {
+            impl<'de> serde::de::Visitor<'de> for __Visitor {
+                type Value = #struct_ident;
+
+                fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    f.write_str(#expecting_msg)
+                }
+
+                fn visit_map<__A>(self, mut map: __A) -> Result<Self::Value, __A::Error>
+                where
+                    __A: serde::de::MapAccess<'de>,
+                {
+                    #(#option_locals)*
+
+                    while let Some(key) = map.next_key::<__Field>()? {
+                        match key {
+                            #(#visit_map_match_arms)*
+                            __Field::__ignore => {
+                                let _ = map.next_value::<serde::de::IgnoredAny>()?;
+                            }
+                        }
+                    }
+
+                    #(#field_resolutions)*
+                    #(#skipped_field_defaults)*
+
+                    Ok(#struct_ident {
+                        #(#all_field_idents,)*
+                    })
+                }
+            }
+        };
+
+        let visitor_instantiation = quote! {
+            __Visitor
+        };
+
+        (visitor_def, visitor_impl, visitor_instantiation)
+    };
+
+    // --- assemble the full deserialize method ---
+    quote! {
+        fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
+        where
+            __D: serde::Deserializer<'de>,
+        {
+            #[allow(non_camel_case_types)]
+            enum __Field {
+                #(#field_enum_variants,)*
+                __ignore,
+            }
+
+            impl<'de> serde::Deserialize<'de> for __Field {
+                fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
+                where
+                    __D: serde::Deserializer<'de>,
+                {
+                    struct __FieldVisitor;
+
+                    impl<'de> serde::de::Visitor<'de> for __FieldVisitor {
+                        type Value = __Field;
+
+                        fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                            f.write_str("field identifier")
+                        }
+
+                        fn visit_str<__E>(self, value: &str) -> Result<__Field, __E>
+                        where
+                            __E: serde::de::Error,
+                        {
+                            match value {
+                                #(#field_match_arms)*
+                                _ => Ok(__Field::__ignore),
+                            }
+                        }
+                    }
+
+                    deserializer.deserialize_identifier(__FieldVisitor)
+                }
+            }
+
+            #visitor_def
+
+            #visitor_impl
+
+            const FIELDS: &[&str] = &[#(#field_names_strs),*];
+            deserializer.deserialize_struct(#struct_name_str, FIELDS, #visitor_instantiation)
+        }
+    }
+}

--- a/derive/src/gen/in_place.rs
+++ b/derive/src/gen/in_place.rs
@@ -1,0 +1,258 @@
+use crate::gen::{collect_type_param_idents, StructDef};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{GenericParam, Ident};
+
+/// Generate the `fn deserialize_in_place<D: Deserializer<'de>>(deserializer: D, place: &mut Self) -> Result<(), D::Error>`
+/// method body for partial-update semantics.
+///
+/// The generated code:
+/// 1. Defines a `__FieldInPlace` enum with variants for each non-skipped field plus `__ignore`
+/// 2. Implements `Deserialize` for `__FieldInPlace` matching string keys (including renamed names and aliases)
+/// 3. Defines an `__InPlaceVisitor<'a>` struct holding `place: &'a mut StructName`
+/// 4. In `visit_map`: matches keys, deserializes values directly into `&mut self.place.field_name`
+/// 5. Skipped fields are never matched — treated as unknown
+/// 6. Unknown keys are consumed via `next_value::<serde::de::IgnoredAny>()`
+pub fn deserialize_in_place(struct_def: &StructDef) -> TokenStream {
+    let struct_ident = &struct_def.ident;
+    let struct_name_str = struct_ident.to_string();
+    let (_impl_generics, ty_generics, _where_clause) = struct_def.generics.split_for_impl();
+
+    // collect non-skipped fields for code generation
+    let active_fields: Vec<_> = struct_def
+        .fields
+        .iter()
+        .filter(|f| !f.attrs.skip_deserializing)
+        .collect();
+
+    // generate enum variant identifiers for each active field
+    let variant_idents: Vec<_> = active_fields
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format_ident!("__field{}", i))
+        .collect();
+
+    // generate match arms for the field key deserializer where each arm matches the serialized name and any aliases
+    let field_match_arms: Vec<TokenStream> = active_fields
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
+            let variant = &variant_idents[i];
+            let primary_name = &field.attrs.serialized_name;
+
+            // Collect all names this field responds to: primary + aliases
+            let mut all_names: Vec<&str> = vec![primary_name.as_str()];
+            for alias in &field.attrs.aliases {
+                all_names.push(alias.as_str());
+            }
+
+            quote! {
+                #(#all_names)|* => Ok(__FieldInPlace::#variant),
+            }
+        })
+        .collect();
+
+    // generate the list of all known field names (for deserialize_struct)
+    let field_names_strs: Vec<&str> = active_fields.iter().map(|f| f.attrs.serialized_name.as_str()).collect();
+
+    // generate visit_map match arms that deserialize into place
+    let visit_map_arms: Vec<TokenStream> = active_fields
+        .iter()
+        .enumerate()
+        .map(|(i, field)| {
+            let variant = &variant_idents[i];
+            let field_ident = &field.ident;
+            let ty = &field.ty;
+            quote! {
+                __FieldInPlace::#variant => {
+                    self.place.#field_ident = map.next_value::<#ty>()?;
+                }
+            }
+        })
+        .collect();
+
+    // generate the expecting message
+    let expecting_msg = format!("struct {}", struct_name_str);
+
+    // generate the __InPlaceVisitor struct and impl based on whether the struct is generic
+    let has_generics = !struct_def.generics.params.is_empty();
+
+    let (visitor_def, visitor_impl) = if has_generics {
+        let type_params: Vec<_> = struct_def
+            .generics
+            .params
+            .iter()
+            .filter_map(|p| match p {
+                GenericParam::Type(tp) => Some(tp),
+                _ => None,
+            })
+            .collect();
+
+        let type_param_idents: Vec<_> = type_params.iter().map(|tp| &tp.ident).collect();
+
+        // build struct definition params with existing bounds
+        let struct_def_params: Vec<TokenStream> = type_params
+            .iter()
+            .map(|tp| {
+                let ident = &tp.ident;
+                let bounds = &tp.bounds;
+                if bounds.is_empty() {
+                    quote! { #ident }
+                } else {
+                    quote! { #ident: #bounds }
+                }
+            })
+            .collect();
+
+        // build bounds for the visitor impl: existing bounds + Deserialize<'de> only for type parameters that appear
+        // in deserializable fields.
+        let deserializable_type_params: std::collections::HashSet<&Ident> = active_fields
+            .iter()
+            .flat_map(|f| {
+                let mut idents = Vec::new();
+                collect_type_param_idents(&f.ty, &type_param_idents, &mut idents);
+                idents
+            })
+            .collect();
+
+        let visitor_impl_bounds: Vec<TokenStream> = type_params
+            .iter()
+            .map(|tp| {
+                let ident = &tp.ident;
+                let bounds = &tp.bounds;
+                let needs_deserialize = deserializable_type_params.contains(ident);
+                match (bounds.is_empty(), needs_deserialize) {
+                    (true, true) => quote! { #ident: serde::Deserialize<'de> },
+                    (true, false) => quote! { #ident },
+                    (false, true) => quote! { #ident: #bounds + serde::Deserialize<'de> },
+                    (false, false) => quote! { #ident: #bounds },
+                }
+            })
+            .collect();
+
+        let visitor_def = quote! {
+            struct __InPlaceVisitor<'__a, #(#struct_def_params),*> {
+                place: &'__a mut #struct_ident #ty_generics,
+            }
+        };
+
+        let visitor_impl = quote! {
+            impl<'__a, 'de, #(#visitor_impl_bounds),*> serde::de::Visitor<'de> for __InPlaceVisitor<'__a, #(#type_param_idents),*> {
+                type Value = ();
+
+                fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    f.write_str(#expecting_msg)
+                }
+
+                #[inline]
+                fn visit_map<__A>(self, mut map: __A) -> Result<Self::Value, __A::Error>
+                where
+                    __A: serde::de::MapAccess<'de>,
+                {
+                    while let Some(key) = map.next_key::<__FieldInPlace>()? {
+                        match key {
+                            #( #visit_map_arms )*
+                            __FieldInPlace::__ignore => {
+                                let _ = map.next_value::<serde::de::IgnoredAny>()?;
+                            }
+                        }
+                    }
+                    Ok(())
+                }
+            }
+        };
+
+        (visitor_def, visitor_impl)
+    } else {
+        let visitor_def = quote! {
+            struct __InPlaceVisitor<'__a> {
+                place: &'__a mut #struct_ident,
+            }
+        };
+
+        let visitor_impl = quote! {
+            impl<'__a, 'de> serde::de::Visitor<'de> for __InPlaceVisitor<'__a> {
+                type Value = ();
+
+                fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                    f.write_str(#expecting_msg)
+                }
+
+                #[inline]
+                fn visit_map<__A>(self, mut map: __A) -> Result<Self::Value, __A::Error>
+                where
+                    __A: serde::de::MapAccess<'de>,
+                {
+                    while let Some(key) = map.next_key::<__FieldInPlace>()? {
+                        match key {
+                            #( #visit_map_arms )*
+                            __FieldInPlace::__ignore => {
+                                let _ = map.next_value::<serde::de::IgnoredAny>()?;
+                            }
+                        }
+                    }
+                    Ok(())
+                }
+            }
+        };
+
+        (visitor_def, visitor_impl)
+    };
+
+    // generate the full deserialize_in_place method
+    quote! {
+        fn deserialize_in_place<__D>(
+            __deserializer: __D,
+            place: &mut Self,
+        ) -> Result<(), __D::Error>
+        where
+            __D: serde::Deserializer<'de>,
+        {
+            #[allow(non_camel_case_types)]
+            enum __FieldInPlace {
+                #( #variant_idents, )*
+                __ignore,
+            }
+
+            impl<'de> serde::Deserialize<'de> for __FieldInPlace {
+                fn deserialize<__D>(deserializer: __D) -> Result<Self, __D::Error>
+                where
+                    __D: serde::Deserializer<'de>,
+                {
+                    struct __FieldInPlaceVisitor;
+
+                    impl<'de> serde::de::Visitor<'de> for __FieldInPlaceVisitor {
+                        type Value = __FieldInPlace;
+
+                        fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                            f.write_str("field identifier")
+                        }
+
+                        fn visit_str<__E>(self, value: &str) -> Result<__FieldInPlace, __E>
+                        where
+                            __E: serde::de::Error,
+                        {
+                            match value {
+                                #( #field_match_arms )*
+                                _ => Ok(__FieldInPlace::__ignore),
+                            }
+                        }
+                    }
+
+                    deserializer.deserialize_identifier(__FieldInPlaceVisitor)
+                }
+            }
+
+            #visitor_def
+
+            #visitor_impl
+
+            const FIELDS: &[&str] = &[#(#field_names_strs),*];
+            __deserializer.deserialize_struct(
+                #struct_name_str,
+                FIELDS,
+                __InPlaceVisitor { place },
+            )
+        }
+    }
+}

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,0 +1,133 @@
+mod attr;
+mod gen;
+mod parse;
+
+use gen::{FieldDef, StructDef};
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, GenericParam, Ident, Result};
+
+/// Derive macro that generates a custom `impl serde::Deserialize<'de>` for named structs.
+///
+/// # Remarks
+///
+/// Unlike serde's default derive, this macro produces a `deserialize_in_place()` method that only updates fields
+/// present in the deserializer's map, leaving absent fields at their current values.
+#[proc_macro_derive(Deserialize, attributes(serde))]
+pub fn derive_deserialize(input: TokenStream) -> TokenStream {
+    match derive_deserialize_impl(input) {
+        Ok(output) => output,
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+fn derive_deserialize_impl(input: TokenStream) -> Result<TokenStream> {
+    // 1. parse the input TokenStream into a DeriveInput
+    let input: DeriveInput = syn::parse(input)?;
+
+    // 2. validate that the input is a named struct
+    let _fields = parse::validate_input(&input)?;
+
+    // 3. parse serde attributes from the struct
+    let parsed = attr::parse_struct_attrs(&input)?;
+
+    // 4. build the StructDef for code generation
+    let struct_def = StructDef {
+        ident: input.ident,
+        generics: input.generics,
+        container_attrs: parsed.container_attrs,
+        fields: parsed
+            .fields
+            .into_iter()
+            .map(|f| FieldDef {
+                ident: f.ident,
+                ty: f.ty,
+                attrs: f.attrs,
+            })
+            .collect(),
+    };
+
+    // 5. generate the deserialize method
+    let deserialize_body = gen::deserialize(&struct_def);
+
+    // 6. generate the deserialize_in_place method
+    let deserialize_in_place_body = gen::deserialize_in_place(&struct_def);
+
+    // 7. build the full impl block
+    let struct_ident = &struct_def.ident;
+    let (_impl_generics, ty_generics, where_clause) = struct_def.generics.split_for_impl();
+
+    // for non-generic structs, we just need `impl<'de>`. for generic structs, we add `T: serde::Deserialize<'de>`
+    // bounds only for type parameters that appear in deserializable (non-skipped) fields
+    let generic_params = &struct_def.generics.params;
+    let output = if generic_params.is_empty() {
+        quote! {
+            #[automatically_derived]
+            impl<'de> serde::Deserialize<'de> for #struct_ident #where_clause {
+                #deserialize_body
+
+                #deserialize_in_place_body
+            }
+        }
+    } else {
+        // collect type parameter identifiers that appear in deserializable fields
+        let deserializable_type_params: std::collections::HashSet<Ident> = struct_def
+            .fields
+            .iter()
+            .filter(|f| !f.attrs.skip_deserializing)
+            .flat_map(|f| extract_type_params(&f.ty, &struct_def.generics))
+            .collect();
+
+        // build impl generics with Deserialize<'de> bounds only on type parameters used in deserializable fields
+        let impl_params = generic_params.iter().map(|param| match param {
+            GenericParam::Type(type_param) => {
+                let ident = &type_param.ident;
+                let existing_bounds = &type_param.bounds;
+                let needs_deserialize = deserializable_type_params.contains(ident);
+                match (existing_bounds.is_empty(), needs_deserialize) {
+                    (true, true) => quote! { #ident: serde::Deserialize<'de> },
+                    (true, false) => quote! { #ident },
+                    (false, true) => quote! { #ident: #existing_bounds + serde::Deserialize<'de> },
+                    (false, false) => quote! { #ident: #existing_bounds },
+                }
+            }
+            GenericParam::Lifetime(lt) => quote! { #lt },
+            GenericParam::Const(cp) => quote! { #cp },
+        });
+
+        // build the where clause, combining existing predicates with any additional ones
+        let where_clause_output = if let Some(wc) = where_clause {
+            quote! { #wc }
+        } else {
+            quote! {}
+        };
+
+        quote! {
+            #[automatically_derived]
+            impl<'de, #(#impl_params),*> serde::Deserialize<'de> for #struct_ident #ty_generics #where_clause_output {
+                #deserialize_body
+
+                #deserialize_in_place_body
+            }
+        }
+    };
+
+    Ok(output.into())
+}
+
+/// Extracts type parameter identifiers from a type that match the struct's generic parameters.
+/// For example, given `Vec<T>` and generics `<T, U>`, this returns `{T}`.
+fn extract_type_params(ty: &syn::Type, generics: &syn::Generics) -> Vec<syn::Ident> {
+    let type_param_idents: Vec<&syn::Ident> = generics
+        .params
+        .iter()
+        .filter_map(|p| match p {
+            GenericParam::Type(tp) => Some(&tp.ident),
+            _ => None,
+        })
+        .collect();
+
+    let mut found = Vec::new();
+    gen::collect_type_param_idents(ty, &type_param_idents, &mut found);
+    found.into_iter().cloned().collect()
+}

--- a/derive/src/parse.rs
+++ b/derive/src/parse.rs
@@ -1,0 +1,21 @@
+use syn::{Data, DeriveInput, Fields, FieldsNamed};
+
+/// Validates that the derive input is a struct with named fields.
+///
+/// Returns the named fields on success, or a compile error if the input
+/// is an enum, tuple struct, or unit struct.
+pub fn validate_input(input: &DeriveInput) -> syn::Result<&FieldsNamed> {
+    match &input.data {
+        Data::Struct(data_struct) => match &data_struct.fields {
+            Fields::Named(fields) => Ok(fields),
+            _ => Err(syn::Error::new_spanned(
+                &input.ident,
+                "config::Deserialize can only be derived for structs with named fields",
+            )),
+        },
+        _ => Err(syn::Error::new_spanned(
+            &input.ident,
+            "config::Deserialize can only be derived for structs with named fields",
+        )),
+    }
+}

--- a/derive/tests/compile_fail.rs
+++ b/derive/tests/compile_fail.rs
@@ -1,0 +1,5 @@
+#[test]
+fn compile_fail_tests() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/compile_fail/*.rs");
+}

--- a/derive/tests/compile_fail/enum.rs
+++ b/derive/tests/compile_fail/enum.rs
@@ -1,0 +1,9 @@
+use config_derive::Deserialize;
+
+#[derive(Deserialize)]
+enum MyEnum {
+    A,
+    B,
+}
+
+fn main() {}

--- a/derive/tests/compile_fail/enum.stderr
+++ b/derive/tests/compile_fail/enum.stderr
@@ -1,0 +1,5 @@
+error: config::Deserialize can only be derived for structs with named fields
+ --> tests/compile_fail/enum.rs:4:6
+  |
+4 | enum MyEnum {
+  |      ^^^^^^

--- a/derive/tests/compile_fail/tuple_struct.rs
+++ b/derive/tests/compile_fail/tuple_struct.rs
@@ -1,0 +1,6 @@
+use config_derive::Deserialize;
+
+#[derive(Deserialize)]
+struct MyTuple(u32, String);
+
+fn main() {}

--- a/derive/tests/compile_fail/tuple_struct.stderr
+++ b/derive/tests/compile_fail/tuple_struct.stderr
@@ -1,0 +1,5 @@
+error: config::Deserialize can only be derived for structs with named fields
+ --> tests/compile_fail/tuple_struct.rs:4:8
+  |
+4 | struct MyTuple(u32, String);
+  |        ^^^^^^^

--- a/derive/tests/compile_fail/unit_struct.rs
+++ b/derive/tests/compile_fail/unit_struct.rs
@@ -1,0 +1,6 @@
+use config_derive::Deserialize;
+
+#[derive(Deserialize)]
+struct MyUnit;
+
+fn main() {}

--- a/derive/tests/compile_fail/unit_struct.stderr
+++ b/derive/tests/compile_fail/unit_struct.stderr
@@ -1,0 +1,5 @@
+error: config::Deserialize can only be derived for structs with named fields
+ --> tests/compile_fail/unit_struct.rs:4:8
+  |
+4 | struct MyUnit;
+  |        ^^^^^^

--- a/derive/tests/compile_fail/unsupported_bound.rs
+++ b/derive/tests/compile_fail/unsupported_bound.rs
@@ -1,0 +1,9 @@
+use config_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(bound = "T: Clone")]
+struct MyStruct<T> {
+    field: T,
+}
+
+fn main() {}

--- a/derive/tests/compile_fail/unsupported_bound.stderr
+++ b/derive/tests/compile_fail/unsupported_bound.stderr
@@ -1,0 +1,5 @@
+error: config::Deserialize does not support #[serde(bound)]
+ --> tests/compile_fail/unsupported_bound.rs:4:9
+  |
+4 | #[serde(bound = "T: Clone")]
+  |         ^^^^^

--- a/derive/tests/compile_fail/unsupported_deserialize_with.rs
+++ b/derive/tests/compile_fail/unsupported_deserialize_with.rs
@@ -1,0 +1,9 @@
+use config_derive::Deserialize;
+
+#[derive(Deserialize)]
+struct MyStruct {
+    #[serde(deserialize_with = "some_function")]
+    field: String,
+}
+
+fn main() {}

--- a/derive/tests/compile_fail/unsupported_deserialize_with.stderr
+++ b/derive/tests/compile_fail/unsupported_deserialize_with.stderr
@@ -1,0 +1,5 @@
+error: config::Deserialize does not support #[serde(deserialize_with)]
+ --> tests/compile_fail/unsupported_deserialize_with.rs:5:13
+  |
+5 |     #[serde(deserialize_with = "some_function")]
+  |             ^^^^^^^^^^^^^^^^

--- a/derive/tests/compile_fail/unsupported_flatten.rs
+++ b/derive/tests/compile_fail/unsupported_flatten.rs
@@ -1,0 +1,9 @@
+use config_derive::Deserialize;
+
+#[derive(Deserialize)]
+struct MyStruct {
+    #[serde(flatten)]
+    inner: std::collections::HashMap<String, String>,
+}
+
+fn main() {}

--- a/derive/tests/compile_fail/unsupported_flatten.stderr
+++ b/derive/tests/compile_fail/unsupported_flatten.stderr
@@ -1,0 +1,5 @@
+error: config::Deserialize does not support #[serde(flatten)]
+ --> tests/compile_fail/unsupported_flatten.rs:5:13
+  |
+5 |     #[serde(flatten)]
+  |             ^^^^^^^

--- a/derive/tests/compile_fail/unsupported_from.rs
+++ b/derive/tests/compile_fail/unsupported_from.rs
@@ -1,0 +1,9 @@
+use config_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(from = "String")]
+struct MyStruct {
+    field: String,
+}
+
+fn main() {}

--- a/derive/tests/compile_fail/unsupported_from.stderr
+++ b/derive/tests/compile_fail/unsupported_from.stderr
@@ -1,0 +1,5 @@
+error: config::Deserialize does not support #[serde(from)]
+ --> tests/compile_fail/unsupported_from.rs:4:9
+  |
+4 | #[serde(from = "String")]
+  |         ^^^^

--- a/derive/tests/compile_fail/unsupported_tag.rs
+++ b/derive/tests/compile_fail/unsupported_tag.rs
@@ -1,0 +1,9 @@
+use config_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+struct MyStruct {
+    field: String,
+}
+
+fn main() {}

--- a/derive/tests/compile_fail/unsupported_tag.stderr
+++ b/derive/tests/compile_fail/unsupported_tag.stderr
@@ -1,0 +1,5 @@
+error: config::Deserialize does not support #[serde(tag)]
+ --> tests/compile_fail/unsupported_tag.rs:4:9
+  |
+4 | #[serde(tag = "type")]
+  |         ^^^

--- a/derive/tests/compile_fail/unsupported_try_from.rs
+++ b/derive/tests/compile_fail/unsupported_try_from.rs
@@ -1,0 +1,9 @@
+use config_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(try_from = "String")]
+struct MyStruct {
+    field: String,
+}
+
+fn main() {}

--- a/derive/tests/compile_fail/unsupported_try_from.stderr
+++ b/derive/tests/compile_fail/unsupported_try_from.stderr
@@ -1,0 +1,5 @@
+error: config::Deserialize does not support #[serde(try_from)]
+ --> tests/compile_fail/unsupported_try_from.rs:4:9
+  |
+4 | #[serde(try_from = "String")]
+  |         ^^^^^^^^

--- a/derive/tests/compile_fail/unsupported_untagged.rs
+++ b/derive/tests/compile_fail/unsupported_untagged.rs
@@ -1,0 +1,9 @@
+use config_derive::Deserialize;
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+struct MyStruct {
+    field: String,
+}
+
+fn main() {}

--- a/derive/tests/compile_fail/unsupported_untagged.stderr
+++ b/derive/tests/compile_fail/unsupported_untagged.stderr
@@ -1,0 +1,5 @@
+error: config::Deserialize does not support #[serde(untagged)]
+ --> tests/compile_fail/unsupported_untagged.rs:4:9
+  |
+4 | #[serde(untagged)]
+  |         ^^^^^^^^

--- a/derive/tests/compile_fail/unsupported_with.rs
+++ b/derive/tests/compile_fail/unsupported_with.rs
@@ -1,0 +1,9 @@
+use config_derive::Deserialize;
+
+#[derive(Deserialize)]
+struct MyStruct {
+    #[serde(with = "some_module")]
+    field: String,
+}
+
+fn main() {}

--- a/derive/tests/compile_fail/unsupported_with.stderr
+++ b/derive/tests/compile_fail/unsupported_with.stderr
@@ -1,0 +1,5 @@
+error: config::Deserialize does not support #[serde(with)]
+ --> tests/compile_fail/unsupported_with.rs:5:13
+  |
+5 |     #[serde(with = "some_module")]
+  |             ^^^^

--- a/derive/tests/deserialize_basic.rs
+++ b/derive/tests/deserialize_basic.rs
@@ -1,0 +1,234 @@
+use config_derive::Deserialize;
+
+/// Basic struct with no special attributes.
+#[derive(Debug, PartialEq, Deserialize)]
+struct Simple {
+    name: String,
+    age: u32,
+}
+
+/// Struct with field-level defaults.
+#[derive(Debug, PartialEq, Deserialize)]
+struct WithDefaults {
+    name: String,
+    #[serde(default)]
+    enabled: bool,
+}
+
+/// Struct with container-level default.
+#[derive(Debug, Default, PartialEq, Deserialize)]
+#[serde(default)]
+struct ContainerDefault {
+    host: String,
+    port: u16,
+}
+
+/// Struct with renamed fields.
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Renamed {
+    server_port: u16,
+    host_name: String,
+}
+
+/// Struct with aliases.
+#[derive(Debug, PartialEq, Deserialize)]
+struct WithAlias {
+    #[serde(alias = "user_name")]
+    name: String,
+}
+
+/// Struct with skipped fields.
+#[derive(Debug, PartialEq, Deserialize)]
+struct WithSkip {
+    name: String,
+    #[serde(skip)]
+    internal: u32,
+}
+
+/// Struct with skip_deserializing.
+#[derive(Debug, PartialEq, Deserialize)]
+struct WithSkipDeserializing {
+    name: String,
+    #[serde(skip_deserializing)]
+    computed: String,
+}
+
+#[test]
+fn deserialize_should_construct_struct_from_complete_json() {
+    // arrange
+    let json = r#"{"name": "Alice", "age": 30}"#;
+
+    // act
+    let result: Simple = serde_json::from_str(json).unwrap();
+
+    // assert
+    assert_eq!(
+        result,
+        Simple {
+            name: "Alice".to_string(),
+            age: 30
+        }
+    );
+}
+
+#[test]
+fn deserialize_should_error_when_required_field_is_missing() {
+    // arrange
+    let json = r#"{"name": "Alice"}"#;
+
+    // act
+    let result = serde_json::from_str::<Simple>(json);
+
+    // assert
+    assert!(result.is_err());
+}
+
+#[test]
+fn deserialize_should_apply_field_default_for_absent_field() {
+    // arrange
+    let json = r#"{"name": "Bob"}"#;
+
+    // act
+    let result: WithDefaults = serde_json::from_str(json).unwrap();
+
+    // assert
+    assert_eq!(
+        result,
+        WithDefaults {
+            name: "Bob".to_string(),
+            enabled: false
+        }
+    );
+}
+
+#[test]
+fn deserialize_should_apply_container_default_for_absent_fields() {
+    // arrange
+    let json = r#"{"host": "localhost"}"#;
+
+    // act
+    let result: ContainerDefault = serde_json::from_str(json).unwrap();
+
+    // assert
+    assert_eq!(
+        result,
+        ContainerDefault {
+            host: "localhost".to_string(),
+            port: 0
+        }
+    );
+}
+
+#[test]
+fn deserialize_should_apply_container_default_for_all_fields_when_empty() {
+    // arrange
+    let json = r#"{}"#;
+
+    // act
+    let result: ContainerDefault = serde_json::from_str(json).unwrap();
+
+    // assert
+    assert_eq!(
+        result,
+        ContainerDefault {
+            host: String::new(),
+            port: 0
+        }
+    );
+}
+
+#[test]
+fn deserialize_should_match_camel_case_renamed_keys() {
+    // arrange
+    let json = r#"{"serverPort": 8080, "hostName": "example.com"}"#;
+
+    // act
+    let result: Renamed = serde_json::from_str(json).unwrap();
+
+    // assert
+    assert_eq!(
+        result,
+        Renamed {
+            server_port: 8080,
+            host_name: "example.com".to_string()
+        }
+    );
+}
+
+#[test]
+fn deserialize_should_accept_primary_name_and_alias() {
+    // arrange / act / assert — primary name
+    let json = r#"{"name": "Alice"}"#;
+    let result: WithAlias = serde_json::from_str(json).unwrap();
+    assert_eq!(
+        result,
+        WithAlias {
+            name: "Alice".to_string()
+        }
+    );
+
+    // arrange / act / assert — alias
+    let json = r#"{"user_name": "Bob"}"#;
+    let result: WithAlias = serde_json::from_str(json).unwrap();
+    assert_eq!(
+        result,
+        WithAlias {
+            name: "Bob".to_string()
+        }
+    );
+}
+
+#[test]
+fn deserialize_should_use_default_for_skipped_field_regardless_of_input() {
+    // arrange
+    let json = r#"{"name": "Alice", "internal": 999}"#;
+
+    // act
+    let result: WithSkip = serde_json::from_str(json).unwrap();
+
+    // assert
+    assert_eq!(
+        result,
+        WithSkip {
+            name: "Alice".to_string(),
+            internal: 0
+        }
+    );
+}
+
+#[test]
+fn deserialize_should_use_default_for_skip_deserializing_field() {
+    // arrange
+    let json = r#"{"name": "Alice", "computed": "should_be_ignored"}"#;
+
+    // act
+    let result: WithSkipDeserializing = serde_json::from_str(json).unwrap();
+
+    // assert
+    assert_eq!(
+        result,
+        WithSkipDeserializing {
+            name: "Alice".to_string(),
+            computed: String::new()
+        }
+    );
+}
+
+#[test]
+fn deserialize_should_ignore_unknown_keys() {
+    // arrange
+    let json = r#"{"name": "Alice", "age": 30, "unknown_field": "ignored"}"#;
+
+    // act
+    let result: Simple = serde_json::from_str(json).unwrap();
+
+    // assert
+    assert_eq!(
+        result,
+        Simple {
+            name: "Alice".to_string(),
+            age: 30
+        }
+    );
+}

--- a/derive/tests/deserialize_generic.rs
+++ b/derive/tests/deserialize_generic.rs
@@ -1,0 +1,238 @@
+use config_derive::Deserialize;
+
+// Single type parameter
+#[derive(Debug, PartialEq, Deserialize)]
+struct Config<T> {
+    value: T,
+    name: String,
+}
+
+// Two type parameters
+#[derive(Debug, PartialEq, Deserialize)]
+struct Pair<A, B> {
+    first: A,
+    second: B,
+}
+
+// Three type parameters
+#[derive(Debug, PartialEq, Deserialize)]
+struct Triple<X, Y, Z> {
+    x: X,
+    y: Y,
+    z: Z,
+}
+
+// Generic with defaults
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(default)]
+struct WithDefault<T: Default> {
+    value: T,
+    label: String,
+}
+
+impl<T: Default> Default for WithDefault<T> {
+    fn default() -> Self {
+        Self {
+            value: T::default(),
+            label: String::new(),
+        }
+    }
+}
+
+// Struct where one type parameter is only used in a skipped field.
+// This verifies that bounds are only applied to type parameters used in
+// deserializable fields (T gets Deserialize bound, S does not need it).
+#[derive(Debug, PartialEq, Deserialize)]
+struct BoundsCheck<T, S: Default> {
+    active: T,
+    #[serde(skip)]
+    skipped: S,
+}
+
+#[test]
+fn deserialize_should_handle_single_type_parameter_with_u32() {
+    // arrange
+    let json = r#"{"value": 42, "name": "test"}"#;
+
+    // act
+    let result: Config<u32> = serde_json::from_str(json).unwrap();
+
+    // assert
+    assert_eq!(
+        result,
+        Config {
+            value: 42,
+            name: "test".to_string()
+        }
+    );
+}
+
+#[test]
+fn deserialize_should_handle_single_type_parameter_with_string() {
+    // arrange
+    let json = r#"{"value": "hello", "name": "test"}"#;
+
+    // act
+    let result: Config<String> = serde_json::from_str(json).unwrap();
+
+    // assert
+    assert_eq!(
+        result,
+        Config {
+            value: "hello".to_string(),
+            name: "test".to_string()
+        }
+    );
+}
+
+#[test]
+fn deserialize_should_handle_two_type_parameters() {
+    // arrange
+    let json = r#"{"first": 1, "second": "two"}"#;
+
+    // act
+    let result: Pair<u32, String> = serde_json::from_str(json).unwrap();
+
+    // assert
+    assert_eq!(
+        result,
+        Pair {
+            first: 1,
+            second: "two".to_string()
+        }
+    );
+}
+
+#[test]
+fn deserialize_should_handle_three_type_parameters() {
+    // arrange
+    let json = r#"{"x": true, "y": 3.14, "z": "hello"}"#;
+
+    // act
+    let result: Triple<bool, f64, String> = serde_json::from_str(json).unwrap();
+
+    // assert
+    assert_eq!(
+        result,
+        Triple {
+            x: true,
+            y: 3.14,
+            z: "hello".to_string()
+        }
+    );
+}
+
+#[test]
+fn deserialize_should_apply_default_for_absent_generic_field() {
+    // arrange
+    let json = r#"{"value": 99}"#;
+
+    // act
+    let result: WithDefault<u32> = serde_json::from_str(json).unwrap();
+
+    // assert
+    assert_eq!(
+        result,
+        WithDefault {
+            value: 99,
+            label: String::new()
+        }
+    );
+}
+
+#[test]
+fn deserialize_in_place_should_update_only_present_fields_for_single_generic() {
+    // arrange
+    let mut instance = Config {
+        value: 10u32,
+        name: "original".to_string(),
+    };
+    let json = r#"{"value": 42}"#;
+
+    // act
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    serde::Deserialize::deserialize_in_place(&mut deserializer, &mut instance).unwrap();
+
+    // assert
+    assert_eq!(instance.value, 42);
+    assert_eq!(instance.name, "original");
+}
+
+#[test]
+fn deserialize_in_place_should_update_only_present_fields_for_pair() {
+    // arrange
+    let mut instance = Pair {
+        first: 1u32,
+        second: "hello".to_string(),
+    };
+    let json = r#"{"second": "world"}"#;
+
+    // act
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    serde::Deserialize::deserialize_in_place(&mut deserializer, &mut instance).unwrap();
+
+    // assert
+    assert_eq!(instance.first, 1);
+    assert_eq!(instance.second, "world");
+}
+
+#[test]
+fn deserialize_in_place_should_update_only_present_fields_for_triple() {
+    // arrange
+    let mut instance = Triple {
+        x: true,
+        y: 1.0f64,
+        z: "original".to_string(),
+    };
+    let json = r#"{"y": 9.99}"#;
+
+    // act
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    serde::Deserialize::deserialize_in_place(&mut deserializer, &mut instance).unwrap();
+
+    // assert
+    assert_eq!(instance.x, true);
+    assert_eq!(instance.y, 9.99);
+    assert_eq!(instance.z, "original");
+}
+
+#[test]
+fn deserialize_should_not_require_bounds_on_skipped_type_parameter() {
+    // arrange
+    #[derive(Debug, PartialEq, Default)]
+    struct NotDeserializable {
+        _data: u8,
+    }
+
+    let json = r#"{"active": 42}"#;
+
+    // act
+    let result: BoundsCheck<u32, NotDeserializable> = serde_json::from_str(json).unwrap();
+
+    // assert
+    assert_eq!(result.active, 42);
+    assert_eq!(result.skipped, NotDeserializable::default());
+}
+
+#[test]
+fn deserialize_in_place_should_not_require_bounds_on_skipped_type_parameter() {
+    // arrange
+    #[derive(Debug, PartialEq, Default)]
+    struct NotDeserializable {
+        _data: u8,
+    }
+
+    let mut instance = BoundsCheck {
+        active: 10u32,
+        skipped: NotDeserializable { _data: 5 },
+    };
+    let json = r#"{"active": 99}"#;
+
+    // act
+    let mut deserializer = serde_json::Deserializer::from_str(json);
+    serde::Deserialize::deserialize_in_place(&mut deserializer, &mut instance).unwrap();
+
+    // assert
+    assert_eq!(instance.active, 99);
+    assert_eq!(instance.skipped._data, 5);
+}

--- a/derive/tests/prop_deserialize.rs
+++ b/derive/tests/prop_deserialize.rs
@@ -1,0 +1,133 @@
+use proptest::prelude::*;
+
+// All fields have #[serde(default)] so any subset can be omitted.
+#[derive(config_derive::Deserialize, serde::Serialize, Clone, Debug, PartialEq)]
+struct AllDefaults {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    count: u32,
+    #[serde(default)]
+    enabled: bool,
+    #[serde(default)]
+    ratio: f64,
+}
+
+// Multiple field types for round-trip testing.
+#[derive(config_derive::Deserialize, serde::Serialize, Clone, Debug, PartialEq)]
+struct MultiField {
+    label: String,
+    value: i64,
+    flag: bool,
+    score: f64,
+}
+
+/// Strategy that generates f64 values which survive JSON round-trip exactly. Uses integer-scaled values that have exact
+/// decimal representations.
+fn json_safe_f64() -> impl Strategy<Value = f64> {
+    // Generate f64 from integer numerator and small denominator to ensure exact JSON round-trip.
+    // Values like n/1, n/2, n/4, n/5, n/8, n/10, etc. are exactly representable.
+    prop_oneof![
+        // Integers (always exact)
+        (-1_000_000i64..1_000_000i64).prop_map(|n| n as f64),
+        // Halves, quarters, eighths
+        (-1_000_000i64..1_000_000i64).prop_map(|n| n as f64 / 2.0),
+        (-1_000_000i64..1_000_000i64).prop_map(|n| n as f64 / 4.0),
+        (-1_000_000i64..1_000_000i64).prop_map(|n| n as f64 / 8.0),
+        // Powers of two scaled
+        (-1_000_000i64..1_000_000i64).prop_map(|n| n as f64 / 16.0),
+        // Small decimals (tenths, hundredths via integer division by powers of 2)
+        (-1_000_000i64..1_000_000i64).prop_map(|n| n as f64 / 256.0),
+    ]
+}
+
+// Generate random subsets of fields to include in JSON. Verify that omitted fields get their Default::default() values.
+proptest! {
+    #[test]
+    fn deserialize_should_process_included_fields_and_have_defaults_for_absent_fields(
+        include_name in any::<bool>(),
+        include_count in any::<bool>(),
+        include_enabled in any::<bool>(),
+        include_ratio in any::<bool>(),
+        name in "[a-zA-Z0-9]{0,20}",
+        count in any::<u32>(),
+        enabled in any::<bool>(),
+        ratio in json_safe_f64(),
+    ) {
+        // arrange
+        let mut fields = Vec::new();
+
+        if include_name {
+            fields.push(format!(r#""name":"{}""#, name));
+        }
+
+        if include_count {
+            fields.push(format!(r#""count":{}"#, count));
+        }
+
+        if include_enabled {
+            fields.push(format!(r#""enabled":{}"#, enabled));
+        }
+
+        if include_ratio {
+            let ratio_json = serde_json::to_string(&ratio).unwrap();
+            fields.push(format!(r#""ratio":{}"#, ratio_json));
+        }
+
+        // act
+        let json = format!("{{{}}}", fields.join(","));
+        let result: AllDefaults = serde_json::from_str(&json).unwrap();
+
+        // assert
+        if include_name {
+            prop_assert_eq!(&result.name, &name);
+        } else {
+            prop_assert_eq!(&result.name, &String::default());
+        }
+
+        if include_count {
+            prop_assert_eq!(result.count, count);
+        } else {
+            prop_assert_eq!(result.count, u32::default());
+        }
+
+        if include_enabled {
+            prop_assert_eq!(result.enabled, enabled);
+        } else {
+            prop_assert_eq!(result.enabled, bool::default());
+        }
+
+        if include_ratio {
+            prop_assert_eq!(result.ratio, ratio);
+        } else {
+            prop_assert_eq!(result.ratio, f64::default());
+        }
+    }
+}
+
+// Generate complete random values for all fields, serialize to JSON, deserialize back, and verify equality.
+proptest! {
+    #[test]
+    fn deserialize_should_roundtrip_using_json(
+        label in "[a-zA-Z0-9]{0,50}",
+        value in any::<i64>(),
+        flag in any::<bool>(),
+        score in json_safe_f64(),
+    ) {
+        // arrange
+        let original = MultiField {
+            label: label.clone(),
+            value,
+            flag,
+            score,
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+
+        // act
+        let deserialized: MultiField = serde_json::from_str(&json).unwrap();
+
+        // assert
+        prop_assert_eq!(&deserialized, &original);
+    }
+}

--- a/derive/tests/prop_rename_alias.rs
+++ b/derive/tests/prop_rename_alias.rs
@@ -1,0 +1,146 @@
+use config_derive::Deserialize;
+use proptest::prelude::*;
+
+/// Struct with `rename_all = "camelCase"` to test that both `deserialize()` and `deserialize_in_place()` match the
+/// transformed (camelCase) key names.
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct RenamedCamelCase {
+    server_port: u16,
+    host_name: String,
+    max_retry_count: u32,
+    is_enabled: bool,
+}
+
+/// Struct with alias attributes to test that both primary name and alias are accepted.
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+#[serde(default)]
+struct WithAliases {
+    #[serde(alias = "user_name")]
+    name: String,
+    #[serde(alias = "server_port")]
+    port: u16,
+    #[serde(alias = "is_active")]
+    active: bool,
+}
+
+impl Default for WithAliases {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            port: 0,
+            active: false,
+        }
+    }
+}
+
+proptest! {
+    #[test]
+    fn deserialize_should_process_camel_case_fields(
+        server_port in any::<u16>(),
+        host_name in "[a-zA-Z][a-zA-Z0-9.\\-]{0,30}",
+        max_retry_count in any::<u32>(),
+        is_enabled in any::<bool>(),
+    ) {
+        // arrange
+        let json = format!(
+            r#"{{"serverPort": {}, "hostName": {:?}, "maxRetryCount": {}, "isEnabled": {}}}"#,
+            server_port, host_name, max_retry_count, is_enabled
+        );
+
+        // act
+        let result: RenamedCamelCase = serde_json::from_str(&json).unwrap();
+
+        // assert
+        prop_assert_eq!(result.server_port, server_port);
+        prop_assert_eq!(&result.host_name, &host_name);
+        prop_assert_eq!(result.max_retry_count, max_retry_count);
+        prop_assert_eq!(result.is_enabled, is_enabled);
+    }
+
+    #[test]
+    fn deserialize_in_place_should_process_camel_case_fields(
+        server_port in any::<u16>(),
+        host_name in "[a-zA-Z][a-zA-Z0-9.\\-]{0,30}",
+        max_retry_count in any::<u32>(),
+        is_enabled in any::<bool>(),
+    ) {
+        // arrange
+        let json = format!(
+            r#"{{"serverPort": {}, "hostName": {:?}, "maxRetryCount": {}, "isEnabled": {}}}"#,
+            server_port, host_name, max_retry_count, is_enabled
+        );
+        let mut place = RenamedCamelCase {
+            server_port: 0,
+            host_name: String::new(),
+            max_retry_count: 0,
+            is_enabled: false,
+        };
+        let mut de = serde_json::Deserializer::from_str(&json);
+
+        // act
+        serde::Deserialize::deserialize_in_place(&mut de, &mut place).unwrap();
+
+        // assert
+        prop_assert_eq!(place.server_port, server_port);
+        prop_assert_eq!(&place.host_name, &host_name);
+        prop_assert_eq!(place.max_retry_count, max_retry_count);
+        prop_assert_eq!(place.is_enabled, is_enabled);
+    }
+
+    #[test]
+    fn deserialize_should_process_aliased_fields(
+        name_val in "[a-zA-Z][a-zA-Z0-9 ]{0,20}",
+        port_val in any::<u16>(),
+        active_val in any::<bool>(),
+        use_alias_for_name in any::<bool>(),
+        use_alias_for_port in any::<bool>(),
+        use_alias_for_active in any::<bool>(),
+    ) {
+        // arrange
+        let name_key = if use_alias_for_name { "user_name" } else { "name" };
+        let port_key = if use_alias_for_port { "server_port" } else { "port" };
+        let active_key = if use_alias_for_active { "is_active" } else { "active" };
+        let json = format!(
+            r#"{{"{name_key}": {:?}, "{port_key}": {port_val}, "{active_key}": {active_val}}}"#,
+            name_val,
+        );
+
+        // act
+        let result: WithAliases = serde_json::from_str(&json).unwrap();
+
+        // assert
+        prop_assert_eq!(&result.name, &name_val);
+        prop_assert_eq!(result.port, port_val);
+        prop_assert_eq!(result.active, active_val);
+    }
+
+    #[test]
+    fn deserialize_in_place_should_process_aliased_fields(
+        name_val in "[a-zA-Z][a-zA-Z0-9 ]{0,20}",
+        port_val in any::<u16>(),
+        active_val in any::<bool>(),
+        use_alias_for_name in any::<bool>(),
+        use_alias_for_port in any::<bool>(),
+        use_alias_for_active in any::<bool>(),
+    ) {
+        // arrange
+        let name_key = if use_alias_for_name { "user_name" } else { "name" };
+        let port_key = if use_alias_for_port { "server_port" } else { "port" };
+        let active_key = if use_alias_for_active { "is_active" } else { "active" };
+        let json = format!(
+            r#"{{"{name_key}": {:?}, "{port_key}": {port_val}, "{active_key}": {active_val}}}"#,
+            name_val,
+        );
+        let mut place = WithAliases::default();
+        let mut de = serde_json::Deserializer::from_str(&json);
+
+        // act
+        serde::Deserialize::deserialize_in_place(&mut de, &mut place).unwrap();
+
+        // assert
+        prop_assert_eq!(&place.name, &name_val);
+        prop_assert_eq!(place.port, port_val);
+        prop_assert_eq!(place.active, active_val);
+    }
+}

--- a/derive/tests/prop_skip.rs
+++ b/derive/tests/prop_skip.rs
@@ -1,0 +1,83 @@
+use proptest::prelude::*;
+
+/// Test struct with some fields marked as skipped. `skipped_num` uses #[serde(skip)] and `skipped_str` uses
+/// #[serde(skip_deserializing)]. Both should never be assigned from the deserializer.
+#[derive(config_derive::Deserialize, Clone, Debug, PartialEq)]
+struct SkipTest {
+    name: String,
+    value: u32,
+    #[serde(skip)]
+    skipped_num: u32,
+    #[serde(skip_deserializing)]
+    skipped_str: String,
+}
+
+fn deserialize_in_place_from_str(place: &mut SkipTest, json: &str) {
+    let mut de = serde_json::Deserializer::from_str(json);
+    serde::Deserialize::deserialize_in_place(&mut de, place).unwrap();
+}
+
+proptest! {
+    #[test]
+    fn deserialize_should_exclude_skipped_fields(
+        name in "[a-zA-Z0-9]{0,20}",
+        value in any::<u32>(),
+        skipped_num_input in any::<u32>(),
+        skipped_str_input in "[a-zA-Z0-9]{0,20}",
+    ) {
+        // arrange
+        let json = format!(
+            r#"{{"name":"{}","value":{},"skipped_num":{},"skipped_str":"{}"}}"#,
+            name, value, skipped_num_input, skipped_str_input
+        );
+
+        // act
+        let result: SkipTest = serde_json::from_str(&json).unwrap();
+
+        prop_assert_eq!(&result.name, &name);
+        prop_assert_eq!(result.value, value);
+        prop_assert_eq!(result.skipped_num, u32::default(),
+            "skipped_num should be default (0), but was {} (JSON had {})",
+            result.skipped_num, skipped_num_input);
+        prop_assert_eq!(&result.skipped_str, &String::default(),
+            "skipped_str should be default (\"\"), but was {:?} (JSON had {:?})",
+            result.skipped_str, skipped_str_input);
+    }
+}
+
+proptest! {
+    #[test]
+    fn deserialize_in_place_should_exclude_skipped_fields(
+        name in "[a-zA-Z0-9]{0,20}",
+        value in any::<u32>(),
+        initial_skipped_num in 1u32..=u32::MAX,
+        initial_skipped_str in "[a-zA-Z]{1,20}",
+        json_skipped_num in any::<u32>(),
+        json_skipped_str in "[a-zA-Z0-9]{0,20}",
+    ) {
+        // arrange
+        let mut instance = SkipTest {
+            name: String::from("original"),
+            value: 0,
+            skipped_num: initial_skipped_num,
+            skipped_str: initial_skipped_str.clone(),
+        };
+        let json = format!(
+            r#"{{"name":"{}","value":{},"skipped_num":{},"skipped_str":"{}"}}"#,
+            name, value, json_skipped_num, json_skipped_str
+        );
+
+        // act
+        deserialize_in_place_from_str(&mut instance, &json);
+
+        // assert
+        prop_assert_eq!(&instance.name, &name);
+        prop_assert_eq!(instance.value, value);
+        prop_assert_eq!(instance.skipped_num, initial_skipped_num,
+            "skipped_num should remain {} but was {} (JSON tried to set {})",
+            initial_skipped_num, instance.skipped_num, json_skipped_num);
+        prop_assert_eq!(&instance.skipped_str, &initial_skipped_str,
+            "skipped_str should remain {:?} but was {:?} (JSON tried to set {:?})",
+            initial_skipped_str, instance.skipped_str, json_skipped_str);
+    }
+}

--- a/derive/tests/properties.rs
+++ b/derive/tests/properties.rs
@@ -1,0 +1,135 @@
+use proptest::prelude::*;
+
+/// Test struct with several fields of different types for property testing.
+#[derive(Clone, Debug, PartialEq, config_derive::Deserialize)]
+struct TestConfig {
+    name: String,
+    count: u32,
+    enabled: bool,
+    ratio: f64,
+}
+
+/// Represents which fields are included in a partial update.
+#[derive(Clone, Debug)]
+struct FieldSubset {
+    include_name: bool,
+    include_count: bool,
+    include_enabled: bool,
+    include_ratio: bool,
+}
+
+/// Build a partial JSON string containing only the fields indicated by the subset, using the "new" values. Uses
+/// serde_json for proper value serialization. Also returns the expected f64 value for ratio after JSON roundtrip.
+fn build_partial_json(new: &TestConfig, subset: &FieldSubset) -> (String, Option<f64>) {
+    use serde_json::{Map, Value};
+
+    let mut map = Map::new();
+
+    if subset.include_name {
+        map.insert("name".to_string(), Value::String(new.name.clone()));
+    }
+    if subset.include_count {
+        map.insert("count".to_string(), Value::from(new.count));
+    }
+    if subset.include_enabled {
+        map.insert("enabled".to_string(), Value::Bool(new.enabled));
+    }
+    if subset.include_ratio {
+        map.insert("ratio".to_string(), serde_json::to_value(new.ratio).unwrap());
+    }
+
+    let json_str = serde_json::to_string(&Value::Object(map)).unwrap();
+
+    let ratio_expected = if subset.include_ratio {
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        Some(parsed["ratio"].as_f64().unwrap())
+    } else {
+        None
+    };
+
+    (json_str, ratio_expected)
+}
+
+/// Strategy to generate arbitrary TestConfig instances.
+fn arb_test_config() -> impl Strategy<Value = TestConfig> {
+    (
+        "[ -~]{0,50}", // printable ASCII strings up to 50 chars
+        any::<u32>(),
+        any::<bool>(),
+        // Use finite f64 values only — JSON cannot represent NaN/Infinity.
+        // Filter the standard f64 strategy to only finite values.
+        any::<f64>().prop_filter("must be finite", |v| v.is_finite()),
+    )
+        .prop_map(|(name, count, enabled, ratio)| TestConfig {
+            name,
+            count,
+            enabled,
+            ratio,
+        })
+}
+
+/// Strategy to generate a random field subset with at least one field included.
+fn arb_field_subset() -> impl Strategy<Value = FieldSubset> {
+    (any::<bool>(), any::<bool>(), any::<bool>(), any::<bool>())
+        .prop_filter("at least one field must be included", |(a, b, c, d)| {
+            *a || *b || *c || *d
+        })
+        .prop_map(|(a, b, c, d)| FieldSubset {
+            include_name: a,
+            include_count: b,
+            include_enabled: c,
+            include_ratio: d,
+        })
+}
+
+proptest! {
+    #[test]
+    fn deserialize_in_place_should_update_fields_present_in_json(
+        initial in arb_test_config(),
+        new_values in arb_test_config(),
+        subset in arb_field_subset(),
+    ) {
+        // arrange
+        let (json, ratio_expected) = build_partial_json(&new_values, &subset);
+        let mut instance = initial.clone();
+        let mut deserializer = serde_json::Deserializer::from_str(&json);
+
+        // act
+        serde::Deserialize::deserialize_in_place(&mut deserializer, &mut instance).unwrap();
+
+        // assert
+        if subset.include_name {
+            prop_assert_eq!(&instance.name, &new_values.name,
+                "name should be updated when present in JSON");
+        } else {
+            prop_assert_eq!(&instance.name, &initial.name,
+                "name should be preserved when absent from JSON");
+        }
+
+        if subset.include_count {
+            prop_assert_eq!(instance.count, new_values.count,
+                "count should be updated when present in JSON");
+        } else {
+            prop_assert_eq!(instance.count, initial.count,
+                "count should be preserved when absent from JSON");
+        }
+
+        if subset.include_enabled {
+            prop_assert_eq!(instance.enabled, new_values.enabled,
+                "enabled should be updated when present in JSON");
+        } else {
+            prop_assert_eq!(instance.enabled, initial.enabled,
+                "enabled should be preserved when absent from JSON");
+        }
+
+        if let Some(expected) = ratio_expected {
+            prop_assert_eq!(instance.ratio.to_bits(), expected.to_bits(),
+                "ratio should be updated when present in JSON: got {:?} expected {:?}",
+                instance.ratio, expected);
+        } else {
+            prop_assert_eq!(instance.ratio.to_bits(), initial.ratio.to_bits(),
+                "ratio should be preserved when absent from JSON: got {:?} expected {:?}",
+                instance.ratio, initial.ratio);
+        }
+    }
+}

--- a/examples/partial_bind.rs
+++ b/examples/partial_bind.rs
@@ -1,5 +1,4 @@
-use config::prelude::*;
-use serde::Deserialize;
+use config::{prelude::*, Deserialize};
 use std::{error::Error, path::Path};
 
 #[derive(Default, Deserialize)]
@@ -23,7 +22,15 @@ fn main() -> Result<(), Box<dyn Error + 'static>> {
         .add_env_vars()
         .add_command_line()
         .build()?;
-    let app: AppOptions = config.reify()?;
+    let mut app = AppOptions::default();
+    let before = &mut app as *mut _;
+
+    config.bind(&mut app)?;
+
+    let after = &mut app as *mut _;
+
+    // verify the pointer wasn't replaced
+    assert_eq!(before, after, "app was replaced");
 
     if app.demo {
         println!("Text = {}", &app.text);

--- a/guide/src/README.md
+++ b/guide/src/README.md
@@ -12,6 +12,7 @@ This crate provides the following features:
 - **chained** - Chain multiple configuration providers
 - **cmd** - Configuration provided by command-line arguments
 - **env** - Configuration provided by environment variables
+- **derive** - Enables full and partial configuration deserialization using **serde**
 - **ini** - Configuration provided by an \*.ini file
 - **json** - Configuration provided by a \*.json file
 - **mem** - Configuration provided by in-memory data

--- a/guide/src/guide/binding.md
+++ b/guide/src/guide/binding.md
@@ -12,25 +12,27 @@ A [Configuration](abstractions.md#configuration) is deserialized through the [Bi
 
 ```rust
 pub trait Binder {
-    fn reify<T>(&self) -> config::Result<T>
-    where
-        T: DeserializeOwned;
+  fn reify<T: DeserializeOwned>(&self) -> config::Result<T>;
 
-    fn bind<T>(&self, instance: &mut T) -> config::Result
-    where
-        T: DeserializeOwned;
+  fn reify_unchecked<T: DeserializeOwned>(&self) -> T;
 
-    fn bind_at<T>(&self, key: impl AsRef<str>, instance: &mut T) -> config::Result
-    where
-        T: DeserializeOwned;
+  fn bind<T: DeserializeOwned>(&self, instance: &mut T) -> config::Result;
 
-    fn get_value<T>(&self, key: impl AsRef<str>) -> Result<Option<T>, T::Err>
-    where
-        T: FromStr;
-    
-    fn get_value_or_default<T>(&self, key: impl AsRef<str>) -> Result<T, T::Err>
-    where
-        T: FromStr + Default;
+  fn bind_unchecked<T: DeserializeOwned>(&self, instance: &mut T);
+
+  fn bind_at<T>(&self, key: impl AsRef<str>, instance: &mut T) -> config::Result
+  where
+      T: DeserializeOwned;
+
+  fn bind_at_unchecked<T>(&self, key: impl AsRef<str>, instance: &mut T)
+  where
+      T: DeserializeOwned;
+
+  fn get_value<T: FromStr>(&self, key: impl AsRef<str>) -> Result<Option<T>, T::Err>;
+  
+  fn get_value_or_default<T>(&self, key: impl AsRef<str>) -> Result<T, T::Err>
+  where
+      T: FromStr + Default;
 }
 ```
 
@@ -116,6 +118,59 @@ fn main() -> Result<(), Box<dyn Error + 'static>> {
 default implementation creates a new struct and binds to it, which is essentially the same as mutating the struct to
 the result of [reify].
 
+## Partial Updates
+
+In order to support partial updates, a drop-in replace is provided using the `config::Deserialize` derive macro. The
+implementation has parity with most the **serde** deserialization capabilities with added support for
+`Deserialize::deserialize_in_place`.
+
+This feature is a meant to support configuration and is not an all purpose deserialization mechanism. If you have
+additional deserialization requirements consider providing an implementation for `Deserialize::deserialize_in_place` or
+use another technique such as an ephemeral struct that can accept the deserialized configuration values and then merge
+that to your general purpose struct.
+
+```rust
+use config::{Deserialize, prelude::*};
+use std::error::Error;
+
+#[derive(Default, Deserialize)]  // ← config::Deserialize instead of serde::Deserialize
+struct ContactOptions {
+    name: String,
+    primary: bool,
+    phones: Vec<String>,
+}
+
+fn main() -> Result<(), Box<dyn Error + 'static>> {
+    let config = config::builder()
+        .add_in_memory(&[
+            ("name", "John Doe"),
+            ("phones:0", "+44 1234567"),
+        ])
+        .build()?;
+    let mut options = ContactOptions::default();
+    let before = &mut options as *mut _;
+
+    config.bind(&mut options)?;
+
+    let after = &mut options as *mut _;
+
+    // verify the pointer wasn't replaced
+    assert_eq!(before, after, "options was replaced");
+
+    println!("{}", &options.name);
+    println!("Phones:");
+
+    for phone in &contact.phones {
+        println!("\n  {phone}");
+    }
+
+    Ok(())
+}
+```
+
+>Partial data binding requires the **derive** feature, which will also trigger activation of the optional
+>**binder** feature.
+
 ## Bind an Array
 
 [bind] supports binding arrays to objects using array indices in configuration keys.
@@ -149,9 +204,7 @@ struct ArrayExample {
 }
 
 fn main() -> Result<(), Box<dyn Error + 'static>> {
-    let config = DefaultConfigurationBuilder::new()
-        .add_json_file("MyArray.json")
-        .build()?;
+    let config = config::builder().add_json_file("MyArray.json").build()?;
     let array: ArrayExample = config.reify()?;
 
     for (i, item) in array.entries.iter().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,11 @@ pub use reloadable::Reloadable;
 pub use section::{OwnedSection, Section};
 pub use settings::Settings;
 
+/// Re-exports the `Deserialize` derive macro from `more-config-derive`.
+#[cfg(feature = "derive")]
+#[cfg_attr(docsrs, doc(cfg(feature = "derive")))]
+pub use config_derive::Deserialize;
+
 /// Represents a configuration result.
 pub type Result<T = ()> = std::result::Result<T, Error>;
 

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,0 +1,304 @@
+use config::prelude::*;
+
+#[derive(Debug, Default, PartialEq, config::Deserialize)]
+#[serde(default)]
+struct AppConfig {
+    host: String,
+    port: u16,
+    debug: bool,
+}
+
+#[derive(Debug, Default, PartialEq, config::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct CamelConfig {
+    server_host: String,
+    server_port: u16,
+    max_retries: u32,
+}
+
+#[derive(Debug, Default, PartialEq, config::Deserialize)]
+#[serde(default)]
+struct SkipConfig {
+    name: String,
+    version: u32,
+    #[serde(skip)]
+    internal_state: String,
+}
+
+#[derive(Debug, Default, PartialEq, config::Deserialize)]
+#[serde(default)]
+struct AliasConfig {
+    #[serde(alias = "user_name")]
+    name: String,
+    age: u32,
+}
+
+#[test]
+fn bind_should_update_only_present_fields() {
+    // arrange
+    let config = config::builder()
+        .add_in_memory(&[("host", "localhost")])
+        .build()
+        .unwrap();
+    let expected = AppConfig {
+        host: "localhost".to_string(),
+        port: 9090,
+        debug: true,
+    };
+    let mut actual = AppConfig {
+        host: "original.com".to_string(),
+        port: 9090,
+        debug: true,
+    };
+
+    // act
+    config.bind(&mut actual).unwrap();
+
+    // assert
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn bind_should_update_multiple_present_fields_but_leaves_absent_unchanged() {
+    // arrange
+    let config = config::builder()
+        .add_in_memory(&[("host", "example.com"), ("debug", "false")])
+        .build()
+        .unwrap();
+    let expected = AppConfig {
+        host: "example.com".to_string(),
+        port: 3000,
+        debug: false,
+    };
+    let mut actual = AppConfig {
+        host: "old.com".to_string(),
+        port: 3000,
+        debug: true,
+    };
+
+    // act
+    config.bind(&mut actual).unwrap();
+
+    // assert
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn bind_should_update_all_fields() {
+    // arrange
+    let config = config::builder()
+        .add_in_memory(&[("host", "new-host"), ("port", "8080"), ("debug", "true")])
+        .build()
+        .unwrap();
+    let expected = AppConfig {
+        host: "new-host".to_string(),
+        port: 8080,
+        debug: true,
+    };
+    let mut actual = AppConfig::default();
+
+    // act
+    config.bind(&mut actual).unwrap();
+
+    // assert
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn bind_with_no_matching_fields_leaves_struct_unchanged() {
+    // arrange
+    let config = config::builder()
+        .add_in_memory(&[("unknown_key", "value")])
+        .build()
+        .unwrap();
+    let expected = AppConfig {
+        host: "keep-me".to_string(),
+        port: 1234,
+        debug: true,
+    };
+    let mut actual = AppConfig {
+        host: "keep-me".to_string(),
+        port: 1234,
+        debug: true,
+    };
+
+    // act
+    config.bind(&mut actual).unwrap();
+
+    // assert
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn bind_should_retain_last_writer() {
+    // arrange
+    let config1 = config::builder()
+        .add_in_memory(&[("host", "first-host"), ("port", "1000")])
+        .build()
+        .unwrap();
+    let config2 = config::builder()
+        .add_in_memory(&[("host", "second-host"), ("debug", "true")])
+        .build()
+        .unwrap();
+    let expected = AppConfig {
+        host: "second-host".to_string(),
+        port: 1000,
+        debug: true,
+    };
+    let mut actual = AppConfig::default();
+
+    // act
+    config1.bind(&mut actual).unwrap();
+    config2.bind(&mut actual).unwrap();
+
+    // assert
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn bind_should_accumulate_updates_across_sources() {
+    // arrange
+    let config_host = config::builder().add_in_memory(&[("host", "my-host")]).build().unwrap();
+    let config_port = config::builder().add_in_memory(&[("port", "5000")]).build().unwrap();
+    let config_debug = config::builder().add_in_memory(&[("debug", "true")]).build().unwrap();
+    let expected = AppConfig {
+        host: "my-host".to_string(),
+        port: 5000,
+        debug: true,
+    };
+    let mut actual = AppConfig::default();
+
+    // act
+    config_host.bind(&mut actual).unwrap();
+    config_port.bind(&mut actual).unwrap();
+    config_debug.bind(&mut actual).unwrap();
+
+    // assert
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn sequential_bind_later_source_overrides_earlier() {
+    // arrange
+    let config1 = config::builder().add_in_memory(&[("port", "3000")]).build().unwrap();
+    let config2 = config::builder().add_in_memory(&[("port", "9000")]).build().unwrap();
+    let expected = AppConfig {
+        port: 9000,
+        host: "unchanged".to_string(),
+        debug: false,
+    };
+    let mut actual = AppConfig {
+        host: "unchanged".to_string(),
+        port: 0,
+        debug: false,
+    };
+
+    // act
+    config1.bind(&mut actual).unwrap();
+
+    assert_eq!(actual.port, 3000);
+
+    config2.bind(&mut actual).unwrap();
+
+    // assert
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn bind_should_never_update_skipped_fields() {
+    // arrange
+    let config = config::builder()
+        .add_in_memory(&[
+            ("name", "test-app"),
+            ("version", "42"),
+            ("internal_state", "should-not-be-set"),
+        ])
+        .build()
+        .unwrap();
+    let expected = SkipConfig {
+        name: "test-app".to_string(),
+        version: 42,
+        internal_state: "preserved".to_string(),
+    };
+    let mut actual = SkipConfig {
+        name: String::new(),
+        version: 0,
+        internal_state: "preserved".to_string(),
+    };
+
+    // act
+    config.bind(&mut actual).unwrap();
+
+    // assert
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn bind_should_match_primary_name_case_insensitively() {
+    // arrange
+    let config = config::builder()
+        .add_in_memory(&[("Name", "Alice"), ("Age", "30")])
+        .build()
+        .unwrap();
+    let expected = AliasConfig {
+        name: "Alice".to_string(),
+        age: 30,
+    };
+    let mut actual = AliasConfig::default();
+
+    // act
+    config.bind(&mut actual).unwrap();
+
+    // assert
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn bind_should_use_camel_case_rename() {
+    // arrange
+    let config = config::builder()
+        .add_in_memory(&[
+            ("serverHost", "api.example.com"),
+            ("serverPort", "443"),
+            ("maxRetries", "5"),
+        ])
+        .build()
+        .unwrap();
+    let expected = CamelConfig {
+        server_host: "api.example.com".to_string(),
+        server_port: 443,
+        max_retries: 5,
+    };
+    let mut actual = CamelConfig::default();
+
+    // act
+    config.bind(&mut actual).unwrap();
+
+    // assert
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn bind_should_perform_partial_update_with_camel_case() {
+    // arrange
+    let config = config::builder()
+        .add_in_memory(&[("serverPort", "8080")])
+        .build()
+        .unwrap();
+    let expected = CamelConfig {
+        server_host: "existing.com".to_string(),
+        server_port: 8080,
+        max_retries: 3,
+    };
+    let mut actual = CamelConfig {
+        server_host: "existing.com".to_string(),
+        server_port: 80,
+        max_retries: 3,
+    };
+
+    // act
+    config.bind(&mut actual).unwrap();
+
+    // assert
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
Adds support for serde's `Deserialize::deserialize_in_place` by using a custom configuration-based derive macro. The `config::Deserialize` derive macro is a drop-in replacement for `serde::Derserialize`. It is only intended for configuration scenarios, but it has as much parity with serde's implementation as possible. This capability is put behind the new **derive** feature. This feature only needs to be activated for users that wish to support in-place, partial updates from configuration.

This PR resolves #10.